### PR TITLE
chore(config): bump root package to 2.0.0 for versioned docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tds-community",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "The TELUS Design System community featuring shared React components",
   "main": "n/a",
   "repository": "git@github.com:telusdigital/tds-community.git",


### PR DESCRIPTION
- bump root package to 2.0.0, that way when deploying docs they'll end up in the `v2.0.0/` directory on production. This helps for posterity and having parity with tds-core, whose docs also end up in the v2.0.0 directory (at the time of this PR)