### PR TITLE
Fix/scaffold

### DIFF
--- a/scripts/scaffolding/package.json
+++ b/scripts/scaffolding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tds/community-$COMPONENT_KEBAB$",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.cjs.js",
   "module": "index.es.js",

--- a/shared/safe-rest/package.json
+++ b/shared/safe-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tds/shared-safe-rest",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "safeRest.js",
   "private": true
 }


### PR DESCRIPTION
* set scaffold base package version to 0.1.0 so that net-new components can be released at 1.0.0
* set shared-safe-rest version to 0.1.0 so that initial release can be 1.0.0 (affects #19)

Yarn prepr:

```
Changes:
 - @tds/community-sample-pilter: 0.1.0 => 1.0.0 (private)
 - @tds/shared-safe-rest: 0.1.0 => 1.0.0 (private)
```