### PR TITLE
docs(github): fix github URLs to use telus and not telusdigital

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -50,6 +50,15 @@
       "contributions": [
         "tds"
       ]
+    },
+    {
+      "login": "jesdavpet",
+      "name": "Jesse David Peterson",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/5464587?v=4",
+      "profile": "http://www.jes.dav.pet",
+      "contributions": [
+        "tds"
+      ]
     }
   ]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -71,7 +71,7 @@ We have incorporated tooling to bake-in and automate as many of these principles
 
 When developing or maintaining community components, they typically undergo the following process:
 
-1.  Commonly-used components are identified by design leads and an issue is opened on GitHub for a member of the [Digital Platform Ambassadors](https://github.com/orgs/telusdigital/teams/digital-platform-ambassadors) (DPA) to delegate to someone to develop **after designs are approved by the DPA**. Note, anyone can open an issue for defects or feature requests.
+1.  Commonly-used components are identified by design leads and an issue is opened on GitHub for a member of the [Digital Platform Ambassadors](https://github.com/orgs/telus/teams/digital-platform-ambassadors) (DPA) to delegate to someone to develop **after designs are approved by the DPA**. Note, anyone can open an issue for defects or feature requests.
 2.  Following the [developer guide](#developer-guide) below, a developer builds a component and then submits a pull request
 3.  Once all checks and criteria are met, a DPA member merges the pull request and updated packages can get deployed to npmjs.org; documentation for components are also updated and published to the [TDS Community Catalogue](https://tds.telus.com/community/index.html)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ maintenance workflow differs. Here is a high level summary:
 | Contribution speed    | Moderate      | High                         |
 | Review board          | TDS Core Team | Digital Platform Ambassadors |
 
-The [Digital Platform Ambassadors](https://github.com/orgs/telusdigital/teams/digital-platform-ambassadors) are a team
+The [Digital Platform Ambassadors](https://github.com/orgs/telus/teams/digital-platform-ambassadors) are a team
 of representatives from every tribe at TELUS digital. They help grow the digital platform and will actively
 review contributions for the TDS Community to ensure quality standards are met.
 
@@ -51,6 +51,6 @@ To learn how to make contributions to TDS Community, See the [contributing guide
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars0.githubusercontent.com/u/10531523?v=4" width="100px;"/><br /><sub><b>Marco Donnici</b></sub>](https://github.com/marcod1419)<br />[](#tds-marcod1419 "") | [<img src="https://avatars0.githubusercontent.com/u/1375942?v=4" width="100px;"/><br /><sub><b>Ryan Oglesby</b></sub>](http://ryanogles.by)<br />[](#tds-ryanoglesby08 "") | [<img src="https://avatars0.githubusercontent.com/u/12798751?v=4" width="100px;"/><br /><sub><b>Enrico Sacchetti</b></sub>](http://theetrain.ca)<br />[](#tds-theetrain "") | [<img src="https://avatars1.githubusercontent.com/u/9420407?v=4" width="100px;"/><br /><sub><b>Jack Reeves</b></sub>](https://github.com/jackreeves)<br />[](#tds-jackreeves "") |
-| :---: | :---: | :---: | :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/10531523?v=4" width="100px;"/><br /><sub><b>Marco Donnici</b></sub>](https://github.com/marcod1419)<br />[](#tds-marcod1419 "") | [<img src="https://avatars0.githubusercontent.com/u/1375942?v=4" width="100px;"/><br /><sub><b>Ryan Oglesby</b></sub>](http://ryanogles.by)<br />[](#tds-ryanoglesby08 "") | [<img src="https://avatars0.githubusercontent.com/u/12798751?v=4" width="100px;"/><br /><sub><b>Enrico Sacchetti</b></sub>](http://theetrain.ca)<br />[](#tds-theetrain "") | [<img src="https://avatars1.githubusercontent.com/u/9420407?v=4" width="100px;"/><br /><sub><b>Jack Reeves</b></sub>](https://github.com/jackreeves)<br />[](#tds-jackreeves "") | [<img src="https://avatars1.githubusercontent.com/u/5464587?v=4" width="100px;"/><br /><sub><b>Jesse David Peterson</b></sub>](http://www.jes.dav.pet)<br />[](#tds-jesdavpet "") |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/guide/README.md
+++ b/guide/README.md
@@ -15,7 +15,7 @@ TDS Community is similar to [TDS Core](https://github.com/telus/tds-core) since 
 | Contribution speed    | Moderate      | High                         |
 | Review board          | TDS Core Team | Digital Platform Ambassadors |
 
-The [Digital Platform Ambassadors](https://github.com/orgs/telusdigital/teams/digital-platform-ambassadors) are a team of representatives from every tribe at TELUS digital. They help grow the digital platform and will actively review contributions for the TDS Community to ensure quality standards are met.
+The [Digital Platform Ambassadors](https://github.com/orgs/telus/teams/digital-platform-ambassadors) are a team of representatives from every tribe at TELUS digital. They help grow the digital platform and will actively review contributions for the TDS Community to ensure quality standards are met.
 
 ## Contributing
 

--- a/packages/Skeleton/package.json
+++ b/packages/Skeleton/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telusdigital/tds-community.git"
+    "url": "git+https://github.com/telus/tds-community.git"
   },
   "publishConfig": {
     "access": "public"
@@ -17,7 +17,7 @@
     "node": ">=8"
   },
   "bugs": {
-    "url": "https://github.com/telusdigital/tds-community/issues"
+    "url": "https://github.com/telus/tds-community/issues"
   },
   "homepage": "http://tds.telus.com",
   "peerDependencies": {


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.
-->

## Description

* Change more URLs from telusdigital to telus
* Add Jesse to contributions table 🎉 

## Package changes

```
 - @tds/community-skeleton: 0.1.0 => 0.2.0
 - @tds/community-sample-pilter: 0.1.0 => 1.0.0 (private)
 - @tds/shared-safe-rest: 0.1.0 => 1.0.0 (private)
```

How come skeleton wants to go to 0.2.0 🤔 

## Checklist before submitting pull request

* Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
* [x] New code is unit tested
* [x] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
  * paste the lerna version output
