### PR TITLE
fix(community-side-navigation): active submenu auto open in site builder

### DIFF
--- a/packages/SideNavigation/SideNavigation.jsx
+++ b/packages/SideNavigation/SideNavigation.jsx
@@ -111,7 +111,7 @@ class SideNavigation extends Component {
   checkActiveState = () => {
     React.Children.map(this.props.children, (child, index) => {
       const id = `TDS-SideNavigation-${index}`
-      if (child.type.name === 'SubMenu' && child.props.active) {
+      if (!('href' in child.props) && child.props.active) {
         this.toggleOpen(id)
       }
     })

--- a/packages/SideNavigation/SubMenu/SubMenu.jsx
+++ b/packages/SideNavigation/SubMenu/SubMenu.jsx
@@ -7,6 +7,7 @@ import Text from '@tds/core-text'
 import { componentWithName } from '@tds/util-prop-types'
 
 import ColoredTextProvider from '../../../shared/components/ColoredTextProvider/ColoredTextProvider'
+import joinClassNames from '../../../shared/utils/joinClassNames'
 
 import styles from './SubMenu.scss'
 
@@ -20,13 +21,18 @@ const SubMenu = ({ children, label, onClick, id, isOpen, active }) => {
     subMenuLink: true,
   }
 
+  const subMenuClasses = joinClassNames(
+    styles.buttonSubMenu,
+    active ? styles.active : styles.buttonDefault
+  )
+
   const onSubMenuClick = () => {
     onClick(id)
   }
 
   return (
     <div className={styles.mainDiv}>
-      <button onClick={onSubMenuClick} className={active ? styles.active : styles.buttonDefault}>
+      <button onClick={onSubMenuClick} className={subMenuClasses}>
         <Box vertical={3} inline horizontal={2} dangerouslyAddClassName={styles.space}>
           <ColoredTextProvider>
             <Text size="medium" bold={active}>

--- a/packages/SideNavigation/SubMenu/SubMenu.scss
+++ b/packages/SideNavigation/SubMenu/SubMenu.scss
@@ -23,7 +23,7 @@ $font-telus: 'TELUS-Web', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   );
 }
 
-button {
+.buttonSubMenu {
   background-color: white;
   border: none;
   width: 100%;

--- a/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
+++ b/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   className="mainDiv"
 >
   <button
-    className="active"
+    className="buttonSubMenu active"
     onClick={[Function]}
   >
     <Box

--- a/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
+++ b/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
@@ -182,7 +182,7 @@ exports[`SideNavigation renders 1`] = `
               className="mainDiv"
             >
               <button
-                className="buttonDefault"
+                className="buttonSubMenu buttonDefault"
                 onClick={[Function]}
               >
                 <Box
@@ -321,7 +321,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
               className="mainDiv"
             >
               <button
-                className="active"
+                className="buttonSubMenu active"
                 onClick={[Function]}
               >
                 <Box


### PR DESCRIPTION
active submenu is not automatically open in site builder because of uglification

- [ x] New code is unit tested
- [ x] make sure visual and accessibility tests pass
- [x ] make sure code builds

lerna notice cli v3.8.0
lerna info versioning independent
lerna info Looking for changed packages since @tds/community-side-navigation@1.0.1
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @tds/community-side-navigation: 1.0.1 => 1.0.2
