### PR TITLE
Side navigation sub menu font

### DIFF
--- a/packages/SideNavigation/SubMenu/SubMenu.jsx
+++ b/packages/SideNavigation/SubMenu/SubMenu.jsx
@@ -27,6 +27,7 @@ const ButtonSubMenu = styled.button(props => ({
   width: '100%',
   color: props.active ? `${colorTelusPurple}` : `${colorShuttleGrey}`,
   borderLeft: props.active ? `4px solid ${colorTelusPurple}` : 'none',
+  fontFamily: 'TELUS-Web, "Helvetica Neue", Helvetica, Arial, sans-serif',
   '&:hover': {
     backgroundColor: `${colorWhiteLilac}`,
     color: `${colorTelusPurple}`,

--- a/packages/SideNavigation/SubMenu/SubMenu.jsx
+++ b/packages/SideNavigation/SubMenu/SubMenu.jsx
@@ -9,6 +9,7 @@ import safeRest from '@tds/shared-safe-rest'
 import { Reveal } from '@tds/shared-animation'
 import { componentWithName } from '@tds/util-prop-types'
 import { colorTelusPurple, colorWhiteLilac, colorShuttleGrey } from '@tds/core-colours'
+import { fontTelus } from '@tds/shared-typography'
 
 import ColoredTextProvider from '../../../shared/components/ColoredTextProvider/ColoredTextProvider'
 
@@ -27,7 +28,7 @@ const ButtonSubMenu = styled.button(props => ({
   width: '100%',
   color: props.active ? `${colorTelusPurple}` : `${colorShuttleGrey}`,
   borderLeft: props.active ? `4px solid ${colorTelusPurple}` : 'none',
-  fontFamily: 'TELUS-Web, "Helvetica Neue", Helvetica, Arial, sans-serif',
+  fontFamily: `${fontTelus}`,
   '&:hover': {
     backgroundColor: `${colorWhiteLilac}`,
     color: `${colorTelusPurple}`,

--- a/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
+++ b/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
+  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c0:hover {

--- a/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
+++ b/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
@@ -29,7 +29,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
-  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "TELUS-Web","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c0:hover {

--- a/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
+++ b/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
@@ -29,7 +29,7 @@ exports[`SideNavigation renders 1`] = `
   width: 100%;
   color: #54595f;
   border-left: none;
-  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "TELUS-Web","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c7:hover {
@@ -181,7 +181,7 @@ exports[`SideNavigation renders 1`] = `
   width: 100%;
   color: #54595f;
   border-left: none;
-  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "TELUS-Web","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c6:hover {
@@ -1752,7 +1752,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
-  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "TELUS-Web","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c7:hover {
@@ -1903,7 +1903,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
-  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "TELUS-Web","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c6:hover {

--- a/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
+++ b/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`SideNavigation renders 1`] = `
   width: 100%;
   color: #54595f;
   border-left: none;
+  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c7:hover {
@@ -180,6 +181,7 @@ exports[`SideNavigation renders 1`] = `
   width: 100%;
   color: #54595f;
   border-left: none;
+  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c6:hover {
@@ -1750,6 +1752,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
+  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c7:hover {
@@ -1900,6 +1903,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   width: 100%;
   color: #4b286d;
   border-left: 4px solid #4b286d;
+  font-family: TELUS-Web,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .c6:hover {

--- a/packages/SideNavigation/package.json
+++ b/packages/SideNavigation/package.json
@@ -31,6 +31,7 @@
     "@tds/core-decorative-icon": "^1.2.0",
     "@tds/core-text": "^1.1.0",
     "@tds/shared-animation": "1.1.0",
+    "@tds/shared-typography": "^1.3.0",
     "@tds/util-prop-types": "^1.3.2",
     "prop-types": "^15.6.2"
   },


### PR DESCRIPTION
Site Builder does not have a default font for buttons.  Need to explicitly state the default font for buttons

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
