### PR TITLE
fix(community-side-navigation): Side nav overflow fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3071,11 +3071,11 @@
       }
     },
     "@tds/shared-animation": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tds/shared-animation/-/shared-animation-1.1.0.tgz",
-      "integrity": "sha512-oDkQa28WPyxZiLS5iCS8sntpI2bKZgL2rr4VWvapIu6cC0ldGG6UWahVNXk+qdEBRzqETe+GJuwh8vrI7vzU4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tds/shared-animation/-/shared-animation-2.1.0.tgz",
+      "integrity": "sha512-gQcYIklFqADxDxSOyg7AFlo3TFQNKEXhLYE2az2bFzAlfpvhSkRGzHd0Vd+fjRSL0jY/Zp1INkAYgWLYWG1Wpg==",
       "requires": {
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.5.10",
         "react-transition-group": "^2.2.1"
       }
     },

--- a/packages/SideNavigation/SideNavigation.jsx
+++ b/packages/SideNavigation/SideNavigation.jsx
@@ -86,7 +86,6 @@ class SideNavigation extends Component {
   componentDidMount() {
     this.checkOffset()
     window.addEventListener('scroll', this.checkOffset)
-    window.addEventListener('click', this.checkOffset)
     this.adjustWidth()
     window.addEventListener('resize', this.adjustWidth)
     this.checkActiveState()
@@ -119,7 +118,6 @@ class SideNavigation extends Component {
 
   removeEventListeners() {
     window.removeEventListener('scroll', this.checkOffset)
-    window.removeEventListener('click', this.checkOffset)
     window.removeEventListener('resize', this.adjustWidth)
   }
 
@@ -143,6 +141,7 @@ class SideNavigation extends Component {
       ((sideNavRect.top < 0 &&
         containerRect.top < 0 &&
         sideNavRect.bottom <= containerRect.bottom &&
+        sideNavRect.bottom > 0 &&
         this.state.variant !== 'bottom') ||
         (sideNavRect.top > 0 && containerRect.top <= 0)) &&
       sideNavRect.height < containerRect.height
@@ -206,6 +205,7 @@ class SideNavigation extends Component {
                     handleToggleSubMenu: this.toggleSubMenu,
                     isOpen: this.checkAccordion(id),
                     id,
+                    callback: this.checkOffset,
                   }
                 }
                 return <StyledLi>{React.cloneElement(child, options)}</StyledLi>

--- a/packages/SideNavigation/SubMenu/SubMenu.jsx
+++ b/packages/SideNavigation/SubMenu/SubMenu.jsx
@@ -6,7 +6,7 @@ import DecorativeIcon from '@tds/core-decorative-icon'
 import Box from '@tds/core-box'
 import Text from '@tds/core-text'
 import { safeRest } from '@tds/util-helpers'
-import { Reveal } from '@tds/shared-animation'
+import { FadeAndReveal } from '@tds/shared-animation'
 import { componentWithName } from '@tds/util-prop-types'
 import { colorTelusPurple, colorWhiteLilac, colorShuttleGrey } from '@tds/core-colours'
 import { fontTelus } from '@tds/shared-typography'
@@ -90,7 +90,7 @@ class SubMenu extends React.Component {
   }
 
   render() {
-    const { children, label, isOpen, callback, ...rest } = this.props
+    const { children, label, isOpen, onOpen, onExit, ...rest } = this.props
 
     const activeChild = this.state.active
     return (
@@ -115,12 +115,13 @@ class SubMenu extends React.Component {
             />
           </SpaceBox>
         </ButtonSubMenu>
-        <Reveal
+        <FadeAndReveal
           timeout={isOpen ? 500 : 0}
           duration={500}
           in={isOpen}
           height={this.state.subMenuHeight}
-          onEntered={callback}
+          onEntered={onOpen}
+          onExited={onExit}
         >
           {() => (
             <SubMenuContainer
@@ -133,7 +134,7 @@ class SubMenu extends React.Component {
               ))}
             </SubMenuContainer>
           )}
-        </Reveal>
+        </FadeAndReveal>
       </React.Fragment>
     )
   }
@@ -176,7 +177,13 @@ SubMenu.propTypes = {
    *
    * @ignore
    */
-  callback: PropTypes.func,
+  onOpen: PropTypes.func,
+  /**
+   * Callback.
+   *
+   * @ignore
+   */
+  onExit: PropTypes.func,
 }
 
 SubMenu.defaultProps = {
@@ -185,7 +192,8 @@ SubMenu.defaultProps = {
   children: undefined,
   id: undefined,
   onClick: undefined,
-  callback: undefined,
+  onOpen: undefined,
+  onExit: undefined,
 }
 
 export default SubMenu

--- a/packages/SideNavigation/SubMenu/SubMenu.jsx
+++ b/packages/SideNavigation/SubMenu/SubMenu.jsx
@@ -90,7 +90,7 @@ class SubMenu extends React.Component {
   }
 
   render() {
-    const { children, label, isOpen, ...rest } = this.props
+    const { children, label, isOpen, callback, ...rest } = this.props
 
     const activeChild = this.state.active
     return (
@@ -120,6 +120,7 @@ class SubMenu extends React.Component {
           duration={500}
           in={isOpen}
           height={this.state.subMenuHeight}
+          onEntered={callback}
         >
           {() => (
             <SubMenuContainer
@@ -170,6 +171,12 @@ SubMenu.propTypes = {
    * @ignore
    */
   onClick: PropTypes.func,
+  /**
+   * Callback.
+   *
+   * @ignore
+   */
+  callback: PropTypes.func,
 }
 
 SubMenu.defaultProps = {
@@ -178,6 +185,7 @@ SubMenu.defaultProps = {
   children: undefined,
   id: undefined,
   onClick: undefined,
+  callback: undefined,
 }
 
 export default SubMenu

--- a/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
+++ b/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
@@ -22,7 +22,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   padding-left: 0.1em;
 }
 
-.c9 {
+.c10 {
   color: #2a2c2e;
   color: inherit;
   word-wrap: break-word;
@@ -35,7 +35,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   font-weight: 500;
 }
 
-.c9 sup {
+.c10 sup {
   top: -0.5em;
   font-size: 0.875rem;
   position: relative;
@@ -43,38 +43,38 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   padding-left: 0.1em;
 }
 
-.c6 {
+.c7 {
   margin-left: 1rem;
   border-left: 4px solid #f2eff4;
 }
 
-.c6:hover {
+.c7:hover {
   background-color: #f2eff4;
 }
 
-.c5 {
+.c6 {
   background-color: none;
 }
 
-.c7 {
+.c8 {
   border-left: none;
   margin-left: -0.25rem;
 }
 
-.c8 {
+.c9 {
   color: #54595f;
 }
 
-.c8:hover {
+.c9:hover {
   color: #4b286d;
 }
 
-.c4 {
+.c5 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c3 {
+.c4 {
   margin-bottom: 1rem;
 }
 
@@ -107,6 +107,13 @@ exports[`SideNavigation.SubMenu renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c3 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
 }
 
 <SubMenu
@@ -227,7 +234,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Text__StyledText-sc-1m0rr67-0",
                                 "isStatic": false,
-                                "lastClassName": "c9",
+                                "lastClassName": "c10",
                                 "rules": Array [
                                   [Function],
                                   [Function],
@@ -289,7 +296,8 @@ exports[`SideNavigation.SubMenu renders 1`] = `
       </button>
     </StyledComponent>
   </SubMenu__ButtonSubMenu>
-  <Reveal
+  <FadeAndReveal
+    delay={0}
     duration={500}
     height={0}
     in={false}
@@ -311,931 +319,980 @@ exports[`SideNavigation.SubMenu renders 1`] = `
       timeout={0}
       unmountOnExit={false}
     >
-      <div
+      <FadeAndReveal__StyledContainer
         aria-hidden={true}
-        data-testid="childrenContainer"
         style={
           Object {
             "height": 0,
+            "opacity": 0,
             "overflow": "hidden",
-            "transition": "height 500ms",
-            "visibility": "hidden",
+            "transition": "height 500ms, opacity 500ms ease-in-out",
           }
         }
       >
-        <SubMenu__SubMenuContainer>
-          <StyledComponent
-            forwardedComponent={
+        <StyledComponent
+          aria-hidden={true}
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+                "isStatic": true,
+                "lastClassName": "c3",
+                "rules": Array [
+                  "@media (prefers-reduced-motion: reduce) {
+  transition: none !important;
+}",
+                ],
+              },
+              "displayName": "FadeAndReveal__StyledContainer",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+          style={
+            Object {
+              "height": 0,
+              "opacity": 0,
+              "overflow": "hidden",
+              "transition": "height 500ms, opacity 500ms ease-in-out",
+            }
+          }
+        >
+          <div
+            aria-hidden={true}
+            className="c3"
+            style={
               Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                  "isStatic": true,
-                  "lastClassName": "c3",
-                  "rules": Array [
-                    "margin-bottom: 1rem;",
-                  ],
-                },
-                "displayName": "SubMenu__SubMenuContainer",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                "target": "ul",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
+                "height": 0,
+                "opacity": 0,
+                "overflow": "hidden",
+                "transition": "height 500ms, opacity 500ms ease-in-out",
               }
             }
-            forwardedRef={[Function]}
           >
-            <ul
-              className="c3"
-            >
-              <li
-                key=".0"
+            <SubMenu__SubMenuContainer>
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                      "isStatic": true,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        "margin-bottom: 1rem;",
+                      ],
+                    },
+                    "displayName": "SubMenu__SubMenuContainer",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                    "target": "ul",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={[Function]}
               >
-                <Link
-                  active={false}
-                  href="#"
-                  reactRouterLinkComponent={null}
-                  subMenuLink={true}
-                  to={null}
+                <ul
+                  className="c4"
                 >
-                  <Link__StyledAnchor
-                    href="#"
-                    to={null}
+                  <li
+                    key=".0"
                   >
-                    <StyledComponent
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Link__StyledAnchor-gur8v7-4",
-                            "isStatic": true,
-                            "lastClassName": "c4",
-                            "rules": Array [
-                              "text-decoration: none;",
-                            ],
-                          },
-                          "displayName": "Link__StyledAnchor",
-                          "foldedComponentIds": Array [],
-                          "render": [Function],
-                          "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                          "target": "a",
-                          "toString": [Function],
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
+                    <Link
+                      active={false}
                       href="#"
+                      reactRouterLinkComponent={null}
+                      subMenuLink={true}
                       to={null}
                     >
-                      <a
-                        className="c4"
+                      <Link__StyledAnchor
                         href="#"
                         to={null}
                       >
-                        <Link__BoxWrapper
-                          active={0}
-                        >
-                          <StyledComponent
-                            active={0}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Link__BoxWrapper-gur8v7-1",
-                                  "isStatic": false,
-                                  "lastClassName": "c5",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Link__BoxWrapper",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Link__StyledAnchor-gur8v7-4",
+                                "isStatic": true,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  "text-decoration: none;",
+                                ],
+                              },
+                              "displayName": "Link__StyledAnchor",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                              "target": "a",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
                             }
-                            forwardedRef={null}
+                          }
+                          forwardedRef={null}
+                          href="#"
+                          to={null}
+                        >
+                          <a
+                            className="c5"
+                            href="#"
+                            to={null}
                           >
-                            <Box
+                            <Link__BoxWrapper
                               active={0}
-                              className="c5"
-                              inline={false}
-                              tag="div"
                             >
-                              <div
+                              <StyledComponent
                                 active={0}
-                                className="c5"
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Link__BoxWrapper-gur8v7-1",
+                                      "isStatic": false,
+                                      "lastClassName": "c6",
+                                      "rules": Array [
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Link__BoxWrapper",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                    "target": [Function],
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
                               >
-                                <Link__BoxContainer
+                                <Box
                                   active={0}
-                                  submenulink={1}
-                                  vertical={3}
+                                  className="c6"
+                                  inline={false}
+                                  tag="div"
                                 >
-                                  <StyledComponent
+                                  <div
                                     active={0}
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "Link__BoxContainer-gur8v7-0",
-                                          "isStatic": false,
-                                          "lastClassName": "c6",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "Link__BoxContainer",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                    submenulink={1}
-                                    vertical={3}
+                                    className="c6"
                                   >
-                                    <Box
+                                    <Link__BoxContainer
                                       active={0}
-                                      className="c6"
-                                      inline={false}
                                       submenulink={1}
-                                      tag="div"
                                       vertical={3}
                                     >
-                                      <div
+                                      <StyledComponent
                                         active={0}
-                                        className="TDS_Box-modules__verticalPadding-3___Fsv37 c6"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Link__BoxContainer-gur8v7-0",
+                                              "isStatic": false,
+                                              "lastClassName": "c7",
+                                              "rules": Array [
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Link__BoxContainer",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                            "target": [Function],
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         submenulink={1}
+                                        vertical={3}
                                       >
-                                        <Link__BoxActive
+                                        <Box
                                           active={0}
-                                          horizontal={3}
+                                          className="c7"
+                                          inline={false}
                                           submenulink={1}
+                                          tag="div"
+                                          vertical={3}
                                         >
-                                          <StyledComponent
+                                          <div
                                             active={0}
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "Link__BoxActive-gur8v7-2",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c7",
-                                                  "rules": Array [
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "Link__BoxActive",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                "target": [Function],
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
-                                            horizontal={3}
+                                            className="TDS_Box-modules__verticalPadding-3___Fsv37 c7"
                                             submenulink={1}
                                           >
-                                            <Box
+                                            <Link__BoxActive
                                               active={0}
-                                              className="c7"
                                               horizontal={3}
-                                              inline={false}
                                               submenulink={1}
-                                              tag="div"
                                             >
-                                              <div
+                                              <StyledComponent
                                                 active={0}
-                                                className="TDS_Box-modules__horizontalPadding-3___2uoUp c7"
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "Link__BoxActive-gur8v7-2",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c8",
+                                                      "rules": Array [
+                                                        [Function],
+                                                      ],
+                                                    },
+                                                    "displayName": "Link__BoxActive",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                    "target": [Function],
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                horizontal={3}
                                                 submenulink={1}
                                               >
-                                                <Link__StyledTextProvider
-                                                  active={false}
+                                                <Box
+                                                  active={0}
+                                                  className="c8"
+                                                  horizontal={3}
+                                                  inline={false}
+                                                  submenulink={1}
+                                                  tag="div"
                                                 >
-                                                  <StyledComponent
-                                                    active={false}
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                          "isStatic": false,
-                                                          "lastClassName": "c8",
-                                                          "rules": Array [
-                                                            [Function],
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledTextProvider",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                        "target": [Function],
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <div
+                                                    active={0}
+                                                    className="TDS_Box-modules__horizontalPadding-3___2uoUp c8"
+                                                    submenulink={1}
                                                   >
-                                                    <ColoredTextProvider
+                                                    <Link__StyledTextProvider
                                                       active={false}
-                                                      className="c8"
                                                     >
-                                                      <div
-                                                        className="c8"
+                                                      <StyledComponent
+                                                        active={false}
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledTextProvider",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                            "target": [Function],
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
                                                       >
-                                                        <Text
-                                                          block={false}
-                                                          bold={false}
-                                                          invert={false}
-                                                          size="small"
+                                                        <ColoredTextProvider
+                                                          active={false}
+                                                          className="c9"
                                                         >
-                                                          <Text__StyledText
-                                                            block={false}
-                                                            bold={false}
-                                                            inheritColor={true}
-                                                            invert={false}
-                                                            size="small"
+                                                          <div
+                                                            className="c9"
                                                           >
-                                                            <StyledComponent
+                                                            <Text
                                                               block={false}
                                                               bold={false}
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c9",
-                                                                    "rules": Array [
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "Text__StyledText",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                  "target": "span",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              inheritColor={true}
                                                               invert={false}
                                                               size="small"
                                                             >
-                                                              <span
-                                                                className="c9"
+                                                              <Text__StyledText
+                                                                block={false}
+                                                                bold={false}
+                                                                inheritColor={true}
+                                                                invert={false}
                                                                 size="small"
                                                               >
-                                                                Option 1
-                                                              </span>
-                                                            </StyledComponent>
-                                                          </Text__StyledText>
-                                                        </Text>
-                                                      </div>
-                                                    </ColoredTextProvider>
-                                                  </StyledComponent>
-                                                </Link__StyledTextProvider>
-                                              </div>
-                                            </Box>
-                                          </StyledComponent>
-                                        </Link__BoxActive>
-                                      </div>
-                                    </Box>
-                                  </StyledComponent>
-                                </Link__BoxContainer>
-                              </div>
-                            </Box>
-                          </StyledComponent>
-                        </Link__BoxWrapper>
-                      </a>
-                    </StyledComponent>
-                  </Link__StyledAnchor>
-                </Link>
-              </li>
-              <li
-                key=".1"
-              >
-                <Link
-                  active={false}
-                  href="#"
-                  reactRouterLinkComponent={null}
-                  subMenuLink={true}
-                  to={null}
-                >
-                  <Link__StyledAnchor
-                    href="#"
-                    to={null}
+                                                                <StyledComponent
+                                                                  block={false}
+                                                                  bold={false}
+                                                                  forwardedComponent={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "attrs": Array [],
+                                                                      "componentStyle": ComponentStyle {
+                                                                        "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                        "isStatic": false,
+                                                                        "lastClassName": "c10",
+                                                                        "rules": Array [
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                        ],
+                                                                      },
+                                                                      "displayName": "Text__StyledText",
+                                                                      "foldedComponentIds": Array [],
+                                                                      "render": [Function],
+                                                                      "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                      "target": "span",
+                                                                      "toString": [Function],
+                                                                      "warnTooManyClasses": [Function],
+                                                                      "withComponent": [Function],
+                                                                    }
+                                                                  }
+                                                                  forwardedRef={null}
+                                                                  inheritColor={true}
+                                                                  invert={false}
+                                                                  size="small"
+                                                                >
+                                                                  <span
+                                                                    className="c10"
+                                                                    size="small"
+                                                                  >
+                                                                    Option 1
+                                                                  </span>
+                                                                </StyledComponent>
+                                                              </Text__StyledText>
+                                                            </Text>
+                                                          </div>
+                                                        </ColoredTextProvider>
+                                                      </StyledComponent>
+                                                    </Link__StyledTextProvider>
+                                                  </div>
+                                                </Box>
+                                              </StyledComponent>
+                                            </Link__BoxActive>
+                                          </div>
+                                        </Box>
+                                      </StyledComponent>
+                                    </Link__BoxContainer>
+                                  </div>
+                                </Box>
+                              </StyledComponent>
+                            </Link__BoxWrapper>
+                          </a>
+                        </StyledComponent>
+                      </Link__StyledAnchor>
+                    </Link>
+                  </li>
+                  <li
+                    key=".1"
                   >
-                    <StyledComponent
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Link__StyledAnchor-gur8v7-4",
-                            "isStatic": true,
-                            "lastClassName": "c4",
-                            "rules": Array [
-                              "text-decoration: none;",
-                            ],
-                          },
-                          "displayName": "Link__StyledAnchor",
-                          "foldedComponentIds": Array [],
-                          "render": [Function],
-                          "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                          "target": "a",
-                          "toString": [Function],
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
+                    <Link
+                      active={false}
                       href="#"
+                      reactRouterLinkComponent={null}
+                      subMenuLink={true}
                       to={null}
                     >
-                      <a
-                        className="c4"
+                      <Link__StyledAnchor
                         href="#"
                         to={null}
                       >
-                        <Link__BoxWrapper
-                          active={0}
-                        >
-                          <StyledComponent
-                            active={0}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Link__BoxWrapper-gur8v7-1",
-                                  "isStatic": false,
-                                  "lastClassName": "c5",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Link__BoxWrapper",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Link__StyledAnchor-gur8v7-4",
+                                "isStatic": true,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  "text-decoration: none;",
+                                ],
+                              },
+                              "displayName": "Link__StyledAnchor",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                              "target": "a",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
                             }
-                            forwardedRef={null}
+                          }
+                          forwardedRef={null}
+                          href="#"
+                          to={null}
+                        >
+                          <a
+                            className="c5"
+                            href="#"
+                            to={null}
                           >
-                            <Box
+                            <Link__BoxWrapper
                               active={0}
-                              className="c5"
-                              inline={false}
-                              tag="div"
                             >
-                              <div
+                              <StyledComponent
                                 active={0}
-                                className="c5"
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Link__BoxWrapper-gur8v7-1",
+                                      "isStatic": false,
+                                      "lastClassName": "c6",
+                                      "rules": Array [
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Link__BoxWrapper",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                    "target": [Function],
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
                               >
-                                <Link__BoxContainer
+                                <Box
                                   active={0}
-                                  submenulink={1}
-                                  vertical={3}
+                                  className="c6"
+                                  inline={false}
+                                  tag="div"
                                 >
-                                  <StyledComponent
+                                  <div
                                     active={0}
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "Link__BoxContainer-gur8v7-0",
-                                          "isStatic": false,
-                                          "lastClassName": "c6",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "Link__BoxContainer",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                    submenulink={1}
-                                    vertical={3}
+                                    className="c6"
                                   >
-                                    <Box
+                                    <Link__BoxContainer
                                       active={0}
-                                      className="c6"
-                                      inline={false}
                                       submenulink={1}
-                                      tag="div"
                                       vertical={3}
                                     >
-                                      <div
+                                      <StyledComponent
                                         active={0}
-                                        className="TDS_Box-modules__verticalPadding-3___Fsv37 c6"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Link__BoxContainer-gur8v7-0",
+                                              "isStatic": false,
+                                              "lastClassName": "c7",
+                                              "rules": Array [
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Link__BoxContainer",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                            "target": [Function],
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         submenulink={1}
+                                        vertical={3}
                                       >
-                                        <Link__BoxActive
+                                        <Box
                                           active={0}
-                                          horizontal={3}
+                                          className="c7"
+                                          inline={false}
                                           submenulink={1}
+                                          tag="div"
+                                          vertical={3}
                                         >
-                                          <StyledComponent
+                                          <div
                                             active={0}
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "Link__BoxActive-gur8v7-2",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c7",
-                                                  "rules": Array [
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "Link__BoxActive",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                "target": [Function],
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
-                                            horizontal={3}
+                                            className="TDS_Box-modules__verticalPadding-3___Fsv37 c7"
                                             submenulink={1}
                                           >
-                                            <Box
+                                            <Link__BoxActive
                                               active={0}
-                                              className="c7"
                                               horizontal={3}
-                                              inline={false}
                                               submenulink={1}
-                                              tag="div"
                                             >
-                                              <div
+                                              <StyledComponent
                                                 active={0}
-                                                className="TDS_Box-modules__horizontalPadding-3___2uoUp c7"
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "Link__BoxActive-gur8v7-2",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c8",
+                                                      "rules": Array [
+                                                        [Function],
+                                                      ],
+                                                    },
+                                                    "displayName": "Link__BoxActive",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                    "target": [Function],
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                horizontal={3}
                                                 submenulink={1}
                                               >
-                                                <Link__StyledTextProvider
-                                                  active={false}
+                                                <Box
+                                                  active={0}
+                                                  className="c8"
+                                                  horizontal={3}
+                                                  inline={false}
+                                                  submenulink={1}
+                                                  tag="div"
                                                 >
-                                                  <StyledComponent
-                                                    active={false}
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                          "isStatic": false,
-                                                          "lastClassName": "c8",
-                                                          "rules": Array [
-                                                            [Function],
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledTextProvider",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                        "target": [Function],
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <div
+                                                    active={0}
+                                                    className="TDS_Box-modules__horizontalPadding-3___2uoUp c8"
+                                                    submenulink={1}
                                                   >
-                                                    <ColoredTextProvider
+                                                    <Link__StyledTextProvider
                                                       active={false}
-                                                      className="c8"
                                                     >
-                                                      <div
-                                                        className="c8"
+                                                      <StyledComponent
+                                                        active={false}
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledTextProvider",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                            "target": [Function],
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
                                                       >
-                                                        <Text
-                                                          block={false}
-                                                          bold={false}
-                                                          invert={false}
-                                                          size="small"
+                                                        <ColoredTextProvider
+                                                          active={false}
+                                                          className="c9"
                                                         >
-                                                          <Text__StyledText
-                                                            block={false}
-                                                            bold={false}
-                                                            inheritColor={true}
-                                                            invert={false}
-                                                            size="small"
+                                                          <div
+                                                            className="c9"
                                                           >
-                                                            <StyledComponent
+                                                            <Text
                                                               block={false}
                                                               bold={false}
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c9",
-                                                                    "rules": Array [
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "Text__StyledText",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                  "target": "span",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              inheritColor={true}
                                                               invert={false}
                                                               size="small"
                                                             >
-                                                              <span
-                                                                className="c9"
+                                                              <Text__StyledText
+                                                                block={false}
+                                                                bold={false}
+                                                                inheritColor={true}
+                                                                invert={false}
                                                                 size="small"
                                                               >
-                                                                Option 2
-                                                              </span>
-                                                            </StyledComponent>
-                                                          </Text__StyledText>
-                                                        </Text>
-                                                      </div>
-                                                    </ColoredTextProvider>
-                                                  </StyledComponent>
-                                                </Link__StyledTextProvider>
-                                              </div>
-                                            </Box>
-                                          </StyledComponent>
-                                        </Link__BoxActive>
-                                      </div>
-                                    </Box>
-                                  </StyledComponent>
-                                </Link__BoxContainer>
-                              </div>
-                            </Box>
-                          </StyledComponent>
-                        </Link__BoxWrapper>
-                      </a>
-                    </StyledComponent>
-                  </Link__StyledAnchor>
-                </Link>
-              </li>
-              <li
-                key=".2"
-              >
-                <Link
-                  active={false}
-                  href="#"
-                  reactRouterLinkComponent={null}
-                  subMenuLink={true}
-                  to={null}
-                >
-                  <Link__StyledAnchor
-                    href="#"
-                    to={null}
+                                                                <StyledComponent
+                                                                  block={false}
+                                                                  bold={false}
+                                                                  forwardedComponent={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "attrs": Array [],
+                                                                      "componentStyle": ComponentStyle {
+                                                                        "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                        "isStatic": false,
+                                                                        "lastClassName": "c10",
+                                                                        "rules": Array [
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                        ],
+                                                                      },
+                                                                      "displayName": "Text__StyledText",
+                                                                      "foldedComponentIds": Array [],
+                                                                      "render": [Function],
+                                                                      "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                      "target": "span",
+                                                                      "toString": [Function],
+                                                                      "warnTooManyClasses": [Function],
+                                                                      "withComponent": [Function],
+                                                                    }
+                                                                  }
+                                                                  forwardedRef={null}
+                                                                  inheritColor={true}
+                                                                  invert={false}
+                                                                  size="small"
+                                                                >
+                                                                  <span
+                                                                    className="c10"
+                                                                    size="small"
+                                                                  >
+                                                                    Option 2
+                                                                  </span>
+                                                                </StyledComponent>
+                                                              </Text__StyledText>
+                                                            </Text>
+                                                          </div>
+                                                        </ColoredTextProvider>
+                                                      </StyledComponent>
+                                                    </Link__StyledTextProvider>
+                                                  </div>
+                                                </Box>
+                                              </StyledComponent>
+                                            </Link__BoxActive>
+                                          </div>
+                                        </Box>
+                                      </StyledComponent>
+                                    </Link__BoxContainer>
+                                  </div>
+                                </Box>
+                              </StyledComponent>
+                            </Link__BoxWrapper>
+                          </a>
+                        </StyledComponent>
+                      </Link__StyledAnchor>
+                    </Link>
+                  </li>
+                  <li
+                    key=".2"
                   >
-                    <StyledComponent
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Link__StyledAnchor-gur8v7-4",
-                            "isStatic": true,
-                            "lastClassName": "c4",
-                            "rules": Array [
-                              "text-decoration: none;",
-                            ],
-                          },
-                          "displayName": "Link__StyledAnchor",
-                          "foldedComponentIds": Array [],
-                          "render": [Function],
-                          "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                          "target": "a",
-                          "toString": [Function],
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
+                    <Link
+                      active={false}
                       href="#"
+                      reactRouterLinkComponent={null}
+                      subMenuLink={true}
                       to={null}
                     >
-                      <a
-                        className="c4"
+                      <Link__StyledAnchor
                         href="#"
                         to={null}
                       >
-                        <Link__BoxWrapper
-                          active={0}
-                        >
-                          <StyledComponent
-                            active={0}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Link__BoxWrapper-gur8v7-1",
-                                  "isStatic": false,
-                                  "lastClassName": "c5",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Link__BoxWrapper",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Link__StyledAnchor-gur8v7-4",
+                                "isStatic": true,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  "text-decoration: none;",
+                                ],
+                              },
+                              "displayName": "Link__StyledAnchor",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                              "target": "a",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
                             }
-                            forwardedRef={null}
+                          }
+                          forwardedRef={null}
+                          href="#"
+                          to={null}
+                        >
+                          <a
+                            className="c5"
+                            href="#"
+                            to={null}
                           >
-                            <Box
+                            <Link__BoxWrapper
                               active={0}
-                              className="c5"
-                              inline={false}
-                              tag="div"
                             >
-                              <div
+                              <StyledComponent
                                 active={0}
-                                className="c5"
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Link__BoxWrapper-gur8v7-1",
+                                      "isStatic": false,
+                                      "lastClassName": "c6",
+                                      "rules": Array [
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Link__BoxWrapper",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                    "target": [Function],
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
                               >
-                                <Link__BoxContainer
+                                <Box
                                   active={0}
-                                  submenulink={1}
-                                  vertical={3}
+                                  className="c6"
+                                  inline={false}
+                                  tag="div"
                                 >
-                                  <StyledComponent
+                                  <div
                                     active={0}
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "Link__BoxContainer-gur8v7-0",
-                                          "isStatic": false,
-                                          "lastClassName": "c6",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "Link__BoxContainer",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                    submenulink={1}
-                                    vertical={3}
+                                    className="c6"
                                   >
-                                    <Box
+                                    <Link__BoxContainer
                                       active={0}
-                                      className="c6"
-                                      inline={false}
                                       submenulink={1}
-                                      tag="div"
                                       vertical={3}
                                     >
-                                      <div
+                                      <StyledComponent
                                         active={0}
-                                        className="TDS_Box-modules__verticalPadding-3___Fsv37 c6"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Link__BoxContainer-gur8v7-0",
+                                              "isStatic": false,
+                                              "lastClassName": "c7",
+                                              "rules": Array [
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Link__BoxContainer",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                            "target": [Function],
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         submenulink={1}
+                                        vertical={3}
                                       >
-                                        <Link__BoxActive
+                                        <Box
                                           active={0}
-                                          horizontal={3}
+                                          className="c7"
+                                          inline={false}
                                           submenulink={1}
+                                          tag="div"
+                                          vertical={3}
                                         >
-                                          <StyledComponent
+                                          <div
                                             active={0}
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "Link__BoxActive-gur8v7-2",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c7",
-                                                  "rules": Array [
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "Link__BoxActive",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                "target": [Function],
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
-                                            horizontal={3}
+                                            className="TDS_Box-modules__verticalPadding-3___Fsv37 c7"
                                             submenulink={1}
                                           >
-                                            <Box
+                                            <Link__BoxActive
                                               active={0}
-                                              className="c7"
                                               horizontal={3}
-                                              inline={false}
                                               submenulink={1}
-                                              tag="div"
                                             >
-                                              <div
+                                              <StyledComponent
                                                 active={0}
-                                                className="TDS_Box-modules__horizontalPadding-3___2uoUp c7"
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "Link__BoxActive-gur8v7-2",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c8",
+                                                      "rules": Array [
+                                                        [Function],
+                                                      ],
+                                                    },
+                                                    "displayName": "Link__BoxActive",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                    "target": [Function],
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                horizontal={3}
                                                 submenulink={1}
                                               >
-                                                <Link__StyledTextProvider
-                                                  active={false}
+                                                <Box
+                                                  active={0}
+                                                  className="c8"
+                                                  horizontal={3}
+                                                  inline={false}
+                                                  submenulink={1}
+                                                  tag="div"
                                                 >
-                                                  <StyledComponent
-                                                    active={false}
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                          "isStatic": false,
-                                                          "lastClassName": "c8",
-                                                          "rules": Array [
-                                                            [Function],
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledTextProvider",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                        "target": [Function],
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <div
+                                                    active={0}
+                                                    className="TDS_Box-modules__horizontalPadding-3___2uoUp c8"
+                                                    submenulink={1}
                                                   >
-                                                    <ColoredTextProvider
+                                                    <Link__StyledTextProvider
                                                       active={false}
-                                                      className="c8"
                                                     >
-                                                      <div
-                                                        className="c8"
+                                                      <StyledComponent
+                                                        active={false}
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledTextProvider",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                            "target": [Function],
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
                                                       >
-                                                        <Text
-                                                          block={false}
-                                                          bold={false}
-                                                          invert={false}
-                                                          size="small"
+                                                        <ColoredTextProvider
+                                                          active={false}
+                                                          className="c9"
                                                         >
-                                                          <Text__StyledText
-                                                            block={false}
-                                                            bold={false}
-                                                            inheritColor={true}
-                                                            invert={false}
-                                                            size="small"
+                                                          <div
+                                                            className="c9"
                                                           >
-                                                            <StyledComponent
+                                                            <Text
                                                               block={false}
                                                               bold={false}
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c9",
-                                                                    "rules": Array [
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      [Function],
-                                                                      "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "Text__StyledText",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                  "target": "span",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              inheritColor={true}
                                                               invert={false}
                                                               size="small"
                                                             >
-                                                              <span
-                                                                className="c9"
+                                                              <Text__StyledText
+                                                                block={false}
+                                                                bold={false}
+                                                                inheritColor={true}
+                                                                invert={false}
                                                                 size="small"
                                                               >
-                                                                Option 3
-                                                              </span>
-                                                            </StyledComponent>
-                                                          </Text__StyledText>
-                                                        </Text>
-                                                      </div>
-                                                    </ColoredTextProvider>
-                                                  </StyledComponent>
-                                                </Link__StyledTextProvider>
-                                              </div>
-                                            </Box>
-                                          </StyledComponent>
-                                        </Link__BoxActive>
-                                      </div>
-                                    </Box>
-                                  </StyledComponent>
-                                </Link__BoxContainer>
-                              </div>
-                            </Box>
-                          </StyledComponent>
-                        </Link__BoxWrapper>
-                      </a>
-                    </StyledComponent>
-                  </Link__StyledAnchor>
-                </Link>
-              </li>
-            </ul>
-          </StyledComponent>
-        </SubMenu__SubMenuContainer>
-      </div>
+                                                                <StyledComponent
+                                                                  block={false}
+                                                                  bold={false}
+                                                                  forwardedComponent={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "attrs": Array [],
+                                                                      "componentStyle": ComponentStyle {
+                                                                        "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                        "isStatic": false,
+                                                                        "lastClassName": "c10",
+                                                                        "rules": Array [
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          [Function],
+                                                                          "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                        ],
+                                                                      },
+                                                                      "displayName": "Text__StyledText",
+                                                                      "foldedComponentIds": Array [],
+                                                                      "render": [Function],
+                                                                      "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                      "target": "span",
+                                                                      "toString": [Function],
+                                                                      "warnTooManyClasses": [Function],
+                                                                      "withComponent": [Function],
+                                                                    }
+                                                                  }
+                                                                  forwardedRef={null}
+                                                                  inheritColor={true}
+                                                                  invert={false}
+                                                                  size="small"
+                                                                >
+                                                                  <span
+                                                                    className="c10"
+                                                                    size="small"
+                                                                  >
+                                                                    Option 3
+                                                                  </span>
+                                                                </StyledComponent>
+                                                              </Text__StyledText>
+                                                            </Text>
+                                                          </div>
+                                                        </ColoredTextProvider>
+                                                      </StyledComponent>
+                                                    </Link__StyledTextProvider>
+                                                  </div>
+                                                </Box>
+                                              </StyledComponent>
+                                            </Link__BoxActive>
+                                          </div>
+                                        </Box>
+                                      </StyledComponent>
+                                    </Link__BoxContainer>
+                                  </div>
+                                </Box>
+                              </StyledComponent>
+                            </Link__BoxWrapper>
+                          </a>
+                        </StyledComponent>
+                      </Link__StyledAnchor>
+                    </Link>
+                  </li>
+                </ul>
+              </StyledComponent>
+            </SubMenu__SubMenuContainer>
+          </div>
+        </StyledComponent>
+      </FadeAndReveal__StyledContainer>
     </Transition>
-  </Reveal>
+  </FadeAndReveal>
 </SubMenu>
 `;

--- a/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
+++ b/packages/SideNavigation/SubMenu/__tests__/__snapshots__/SubMenu.spec.jsx.snap
@@ -327,6 +327,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
             "opacity": 0,
             "overflow": "hidden",
             "transition": "height 500ms, opacity 500ms ease-in-out",
+            "visibility": "hidden",
           }
         }
       >
@@ -363,6 +364,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
               "opacity": 0,
               "overflow": "hidden",
               "transition": "height 500ms, opacity 500ms ease-in-out",
+              "visibility": "hidden",
             }
           }
         >
@@ -375,6 +377,7 @@ exports[`SideNavigation.SubMenu renders 1`] = `
                 "opacity": 0,
                 "overflow": "hidden",
                 "transition": "height 500ms, opacity 500ms ease-in-out",
+                "visibility": "hidden",
               }
             }
           >

--- a/packages/SideNavigation/__tests__/SideNavigation.spec.jsx
+++ b/packages/SideNavigation/__tests__/SideNavigation.spec.jsx
@@ -133,9 +133,8 @@ describe('SideNavigation', () => {
     window.removeEventListener = jest.fn()
 
     sideNavigation.instance().removeEventListeners()
-    expect(window.removeEventListener).toHaveBeenCalledTimes(3)
+    expect(window.removeEventListener).toHaveBeenCalledTimes(2)
     expect(window.removeEventListener.mock.calls[0]).toContain('scroll')
-    expect(window.removeEventListener.mock.calls[1]).toContain('click')
-    expect(window.removeEventListener.mock.calls[2]).toContain('resize')
+    expect(window.removeEventListener.mock.calls[1]).toContain('resize')
   })
 })

--- a/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
+++ b/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
@@ -533,7 +533,7 @@ exports[`SideNavigation renders 1`] = `
                         <div
                           aria-hidden="true"
                           class="c11"
-                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 0; height: 0px; overflow: hidden;"
+                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 0; height: 0px; overflow: hidden; visibility: hidden;"
                         >
                           <ul
                             class="c12"
@@ -1904,6 +1904,7 @@ exports[`SideNavigation renders 1`] = `
                                           "opacity": 0,
                                           "overflow": "hidden",
                                           "transition": "height 500ms, opacity 500ms ease-in-out",
+                                          "visibility": "hidden",
                                         }
                                       }
                                     >
@@ -1940,6 +1941,7 @@ exports[`SideNavigation renders 1`] = `
                                             "opacity": 0,
                                             "overflow": "hidden",
                                             "transition": "height 500ms, opacity 500ms ease-in-out",
+                                            "visibility": "hidden",
                                           }
                                         }
                                       >
@@ -1952,6 +1954,7 @@ exports[`SideNavigation renders 1`] = `
                                               "opacity": 0,
                                               "overflow": "hidden",
                                               "transition": "height 500ms, opacity 500ms ease-in-out",
+                                              "visibility": "hidden",
                                             }
                                           }
                                         >
@@ -3415,7 +3418,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                         <div
                           aria-hidden="false"
                           class="c12"
-                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 1; height: 0px; overflow: hidden;"
+                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 1; height: 0px; overflow: hidden; visibility: visible;"
                         >
                           <ul
                             class="c13"
@@ -4075,6 +4078,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                           "opacity": 1,
                                           "overflow": "hidden",
                                           "transition": "height 500ms, opacity 500ms ease-in-out",
+                                          "visibility": "visible",
                                         }
                                       }
                                     >
@@ -4111,6 +4115,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                             "opacity": 1,
                                             "overflow": "hidden",
                                             "transition": "height 500ms, opacity 500ms ease-in-out",
+                                            "visibility": "visible",
                                           }
                                         }
                                       >
@@ -4123,6 +4128,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                               "opacity": 1,
                                               "overflow": "hidden",
                                               "transition": "height 500ms, opacity 500ms ease-in-out",
+                                              "visibility": "visible",
                                             }
                                           }
                                         >

--- a/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
+++ b/packages/SideNavigation/__tests__/__snapshots__/SideNavigation.spec.jsx.snap
@@ -22,7 +22,7 @@ exports[`SideNavigation renders 1`] = `
   padding-left: 0.1em;
 }
 
-.c15 {
+.c16 {
   color: #2a2c2e;
   color: inherit;
   word-wrap: break-word;
@@ -35,7 +35,7 @@ exports[`SideNavigation renders 1`] = `
   font-weight: 500;
 }
 
-.c15 sup {
+.c16 sup {
   top: -0.5em;
   font-size: 0.875rem;
   position: relative;
@@ -52,12 +52,12 @@ exports[`SideNavigation renders 1`] = `
   background-color: #f2eff4;
 }
 
-.c13 {
+.c14 {
   margin-left: 1rem;
   border-left: 4px solid #f2eff4;
 }
 
-.c13:hover {
+.c14:hover {
   background-color: #f2eff4;
 }
 
@@ -70,7 +70,7 @@ exports[`SideNavigation renders 1`] = `
   margin-left: 0px;
 }
 
-.c14 {
+.c15 {
   border-left: none;
   margin-left: -0.25rem;
 }
@@ -88,7 +88,7 @@ exports[`SideNavigation renders 1`] = `
   text-decoration: none;
 }
 
-.c12 {
+.c13 {
   margin-bottom: 1rem;
 }
 
@@ -159,6 +159,13 @@ exports[`SideNavigation renders 1`] = `
   -ms-flex-align: center;
   align-items: center;
   line-height: 0;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c12 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
 }
 
 <SideNavigation
@@ -243,7 +250,7 @@ exports[`SideNavigation renders 1`] = `
   padding-left: 0.1em;
 }
 
-.c14 {
+.c15 {
   color: #2a2c2e;
   color: inherit;
   word-wrap: break-word;
@@ -256,7 +263,7 @@ exports[`SideNavigation renders 1`] = `
   font-weight: 500;
 }
 
-.c14 sup {
+.c15 sup {
   top: -0.5em;
   font-size: 0.875rem;
   position: relative;
@@ -273,12 +280,12 @@ exports[`SideNavigation renders 1`] = `
   background-color: #f2eff4;
 }
 
-.c12 {
+.c13 {
   margin-left: 1rem;
   border-left: 4px solid #f2eff4;
 }
 
-.c12:hover {
+.c13:hover {
   background-color: #f2eff4;
 }
 
@@ -291,7 +298,7 @@ exports[`SideNavigation renders 1`] = `
   margin-left: 0px;
 }
 
-.c13 {
+.c14 {
   border-left: none;
   margin-left: -0.25rem;
 }
@@ -309,7 +316,7 @@ exports[`SideNavigation renders 1`] = `
   text-decoration: none;
 }
 
-.c11 {
+.c12 {
   margin-bottom: 1rem;
 }
 
@@ -375,6 +382,13 @@ exports[`SideNavigation renders 1`] = `
   -ms-flex-align: center;
   align-items: center;
   line-height: 0;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c11 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
 }
 
 <div
@@ -518,11 +532,11 @@ exports[`SideNavigation renders 1`] = `
                         </button>
                         <div
                           aria-hidden="true"
-                          data-testid="childrenContainer"
-                          style="transition: height 500ms; height: 0px; overflow: hidden; visibility: hidden;"
+                          class="c11"
+                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 0; height: 0px; overflow: hidden;"
                         >
                           <ul
-                            class="c11"
+                            class="c12"
                           >
                             <li>
                               <a
@@ -535,19 +549,19 @@ exports[`SideNavigation renders 1`] = `
                                 >
                                   <div
                                     active="0"
-                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c12"
+                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
                                     submenulink="1"
                                   >
                                     <div
                                       active="0"
-                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c13"
+                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
                                       submenulink="1"
                                     >
                                       <div
                                         class="c7"
                                       >
                                         <span
-                                          class="c14"
+                                          class="c15"
                                         >
                                           Option 1
                                         </span>
@@ -568,19 +582,19 @@ exports[`SideNavigation renders 1`] = `
                                 >
                                   <div
                                     active="0"
-                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c12"
+                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
                                     submenulink="1"
                                   >
                                     <div
                                       active="0"
-                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c13"
+                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
                                       submenulink="1"
                                     >
                                       <div
                                         class="c7"
                                       >
                                         <span
-                                          class="c14"
+                                          class="c15"
                                         >
                                           Option 2
                                         </span>
@@ -601,19 +615,19 @@ exports[`SideNavigation renders 1`] = `
                                 >
                                   <div
                                     active="0"
-                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c12"
+                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
                                     submenulink="1"
                                   >
                                     <div
                                       active="0"
-                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c13"
+                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
                                       submenulink="1"
                                     >
                                       <div
                                         class="c7"
                                       >
                                         <span
-                                          class="c14"
+                                          class="c15"
                                         >
                                           Option 3
                                         </span>
@@ -800,7 +814,7 @@ exports[`SideNavigation renders 1`] = `
                                                       "componentStyle": ComponentStyle {
                                                         "componentId": "Link__BoxContainer-gur8v7-0",
                                                         "isStatic": false,
-                                                        "lastClassName": "c13",
+                                                        "lastClassName": "c14",
                                                         "rules": Array [
                                                           [Function],
                                                         ],
@@ -846,7 +860,7 @@ exports[`SideNavigation renders 1`] = `
                                                               "componentStyle": ComponentStyle {
                                                                 "componentId": "Link__BoxActive-gur8v7-2",
                                                                 "isStatic": false,
-                                                                "lastClassName": "c14",
+                                                                "lastClassName": "c15",
                                                                 "rules": Array [
                                                                   [Function],
                                                                 ],
@@ -937,7 +951,7 @@ exports[`SideNavigation renders 1`] = `
                                                                                 "componentStyle": ComponentStyle {
                                                                                   "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                                                   "isStatic": false,
-                                                                                  "lastClassName": "c15",
+                                                                                  "lastClassName": "c16",
                                                                                   "rules": Array [
                                                                                     [Function],
                                                                                     [Function],
@@ -1123,7 +1137,7 @@ exports[`SideNavigation renders 1`] = `
                                                       "componentStyle": ComponentStyle {
                                                         "componentId": "Link__BoxContainer-gur8v7-0",
                                                         "isStatic": false,
-                                                        "lastClassName": "c13",
+                                                        "lastClassName": "c14",
                                                         "rules": Array [
                                                           [Function],
                                                         ],
@@ -1169,7 +1183,7 @@ exports[`SideNavigation renders 1`] = `
                                                               "componentStyle": ComponentStyle {
                                                                 "componentId": "Link__BoxActive-gur8v7-2",
                                                                 "isStatic": false,
-                                                                "lastClassName": "c14",
+                                                                "lastClassName": "c15",
                                                                 "rules": Array [
                                                                   [Function],
                                                                 ],
@@ -1260,7 +1274,7 @@ exports[`SideNavigation renders 1`] = `
                                                                                 "componentStyle": ComponentStyle {
                                                                                   "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                                                   "isStatic": false,
-                                                                                  "lastClassName": "c15",
+                                                                                  "lastClassName": "c16",
                                                                                   "rules": Array [
                                                                                     [Function],
                                                                                     [Function],
@@ -1446,7 +1460,7 @@ exports[`SideNavigation renders 1`] = `
                                                       "componentStyle": ComponentStyle {
                                                         "componentId": "Link__BoxContainer-gur8v7-0",
                                                         "isStatic": false,
-                                                        "lastClassName": "c13",
+                                                        "lastClassName": "c14",
                                                         "rules": Array [
                                                           [Function],
                                                         ],
@@ -1492,7 +1506,7 @@ exports[`SideNavigation renders 1`] = `
                                                               "componentStyle": ComponentStyle {
                                                                 "componentId": "Link__BoxActive-gur8v7-2",
                                                                 "isStatic": false,
-                                                                "lastClassName": "c14",
+                                                                "lastClassName": "c15",
                                                                 "rules": Array [
                                                                   [Function],
                                                                 ],
@@ -1583,7 +1597,7 @@ exports[`SideNavigation renders 1`] = `
                                                                                 "componentStyle": ComponentStyle {
                                                                                   "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                                                   "isStatic": false,
-                                                                                  "lastClassName": "c15",
+                                                                                  "lastClassName": "c16",
                                                                                   "rules": Array [
                                                                                     [Function],
                                                                                     [Function],
@@ -1679,6 +1693,8 @@ exports[`SideNavigation renders 1`] = `
                                 isOpen={false}
                                 label="Threefdsfdsfds"
                                 onClick={[Function]}
+                                onExit={[Function]}
+                                onOpen={[Function]}
                               >
                                 <SubMenu__ButtonSubMenu
                                   aria-expanded={false}
@@ -1793,7 +1809,7 @@ exports[`SideNavigation renders 1`] = `
                                                             "componentStyle": ComponentStyle {
                                                               "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                               "isStatic": false,
-                                                              "lastClassName": "c15",
+                                                              "lastClassName": "c16",
                                                               "rules": Array [
                                                                 [Function],
                                                                 [Function],
@@ -1855,10 +1871,13 @@ exports[`SideNavigation renders 1`] = `
                                     </button>
                                   </StyledComponent>
                                 </SubMenu__ButtonSubMenu>
-                                <Reveal
+                                <FadeAndReveal
+                                  delay={0}
                                   duration={500}
                                   height={0}
                                   in={false}
+                                  onEntered={[Function]}
+                                  onExited={[Function]}
                                   timeout={0}
                                 >
                                   <Transition
@@ -1877,932 +1896,981 @@ exports[`SideNavigation renders 1`] = `
                                     timeout={0}
                                     unmountOnExit={false}
                                   >
-                                    <div
+                                    <FadeAndReveal__StyledContainer
                                       aria-hidden={true}
-                                      data-testid="childrenContainer"
                                       style={
                                         Object {
                                           "height": 0,
+                                          "opacity": 0,
                                           "overflow": "hidden",
-                                          "transition": "height 500ms",
-                                          "visibility": "hidden",
+                                          "transition": "height 500ms, opacity 500ms ease-in-out",
                                         }
                                       }
                                     >
-                                      <SubMenu__SubMenuContainer>
-                                        <StyledComponent
-                                          forwardedComponent={
+                                      <StyledComponent
+                                        aria-hidden={true}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c12",
+                                              "rules": Array [
+                                                "@media (prefers-reduced-motion: reduce) {
+  transition: none !important;
+}",
+                                              ],
+                                            },
+                                            "displayName": "FadeAndReveal__StyledContainer",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+                                            "target": "div",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "opacity": 0,
+                                            "overflow": "hidden",
+                                            "transition": "height 500ms, opacity 500ms ease-in-out",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          aria-hidden={true}
+                                          className="c12"
+                                          style={
                                             Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                                                "isStatic": true,
-                                                "lastClassName": "c12",
-                                                "rules": Array [
-                                                  "margin-bottom: 1rem;",
-                                                ],
-                                              },
-                                              "displayName": "SubMenu__SubMenuContainer",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                                              "target": "ul",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
+                                              "height": 0,
+                                              "opacity": 0,
+                                              "overflow": "hidden",
+                                              "transition": "height 500ms, opacity 500ms ease-in-out",
                                             }
                                           }
-                                          forwardedRef={[Function]}
                                         >
-                                          <ul
-                                            className="c12"
-                                          >
-                                            <li
-                                              key=".0"
+                                          <SubMenu__SubMenuContainer>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c13",
+                                                    "rules": Array [
+                                                      "margin-bottom: 1rem;",
+                                                    ],
+                                                  },
+                                                  "displayName": "SubMenu__SubMenuContainer",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                                                  "target": "ul",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={[Function]}
                                             >
-                                              <Link
-                                                active={false}
-                                                href="#"
-                                                reactRouterLinkComponent={null}
-                                                subMenuLink={true}
-                                                to={null}
+                                              <ul
+                                                className="c13"
                                               >
-                                                <Link__StyledAnchor
-                                                  href="#"
-                                                  to={null}
+                                                <li
+                                                  key=".0"
                                                 >
-                                                  <StyledComponent
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledAnchor-gur8v7-4",
-                                                          "isStatic": true,
-                                                          "lastClassName": "c4",
-                                                          "rules": Array [
-                                                            "text-decoration: none;",
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledAnchor",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <Link
+                                                    active={false}
                                                     href="#"
+                                                    reactRouterLinkComponent={null}
+                                                    subMenuLink={true}
                                                     to={null}
                                                   >
-                                                    <a
-                                                      className="c4"
+                                                    <Link__StyledAnchor
                                                       href="#"
                                                       to={null}
                                                     >
-                                                      <Link__BoxWrapper
-                                                        active={0}
-                                                      >
-                                                        <StyledComponent
-                                                          active={0}
-                                                          forwardedComponent={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "attrs": Array [],
-                                                              "componentStyle": ComponentStyle {
-                                                                "componentId": "Link__BoxWrapper-gur8v7-1",
-                                                                "isStatic": false,
-                                                                "lastClassName": "c5",
-                                                                "rules": Array [
-                                                                  [Function],
-                                                                ],
-                                                              },
-                                                              "displayName": "Link__BoxWrapper",
-                                                              "foldedComponentIds": Array [],
-                                                              "render": [Function],
-                                                              "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                                              "target": [Function],
-                                                              "toString": [Function],
-                                                              "warnTooManyClasses": [Function],
-                                                              "withComponent": [Function],
-                                                            }
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledAnchor-gur8v7-4",
+                                                              "isStatic": true,
+                                                              "lastClassName": "c4",
+                                                              "rules": Array [
+                                                                "text-decoration: none;",
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledAnchor",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
                                                           }
-                                                          forwardedRef={null}
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="#"
+                                                        to={null}
+                                                      >
+                                                        <a
+                                                          className="c4"
+                                                          href="#"
+                                                          to={null}
                                                         >
-                                                          <Box
+                                                          <Link__BoxWrapper
                                                             active={0}
-                                                            className="c5"
-                                                            inline={false}
-                                                            tag="div"
                                                           >
-                                                            <div
+                                                            <StyledComponent
                                                               active={0}
-                                                              className="c5"
+                                                              forwardedComponent={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "attrs": Array [],
+                                                                  "componentStyle": ComponentStyle {
+                                                                    "componentId": "Link__BoxWrapper-gur8v7-1",
+                                                                    "isStatic": false,
+                                                                    "lastClassName": "c5",
+                                                                    "rules": Array [
+                                                                      [Function],
+                                                                    ],
+                                                                  },
+                                                                  "displayName": "Link__BoxWrapper",
+                                                                  "foldedComponentIds": Array [],
+                                                                  "render": [Function],
+                                                                  "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                                                  "target": [Function],
+                                                                  "toString": [Function],
+                                                                  "warnTooManyClasses": [Function],
+                                                                  "withComponent": [Function],
+                                                                }
+                                                              }
+                                                              forwardedRef={null}
                                                             >
-                                                              <Link__BoxContainer
+                                                              <Box
                                                                 active={0}
-                                                                submenulink={1}
-                                                                vertical={3}
+                                                                className="c5"
+                                                                inline={false}
+                                                                tag="div"
                                                               >
-                                                                <StyledComponent
+                                                                <div
                                                                   active={0}
-                                                                  forwardedComponent={
-                                                                    Object {
-                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                      "attrs": Array [],
-                                                                      "componentStyle": ComponentStyle {
-                                                                        "componentId": "Link__BoxContainer-gur8v7-0",
-                                                                        "isStatic": false,
-                                                                        "lastClassName": "c13",
-                                                                        "rules": Array [
-                                                                          [Function],
-                                                                        ],
-                                                                      },
-                                                                      "displayName": "Link__BoxContainer",
-                                                                      "foldedComponentIds": Array [],
-                                                                      "render": [Function],
-                                                                      "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                                                      "target": [Function],
-                                                                      "toString": [Function],
-                                                                      "warnTooManyClasses": [Function],
-                                                                      "withComponent": [Function],
-                                                                    }
-                                                                  }
-                                                                  forwardedRef={null}
-                                                                  submenulink={1}
-                                                                  vertical={3}
+                                                                  className="c5"
                                                                 >
-                                                                  <Box
+                                                                  <Link__BoxContainer
                                                                     active={0}
-                                                                    className="c13"
-                                                                    inline={false}
                                                                     submenulink={1}
-                                                                    tag="div"
                                                                     vertical={3}
                                                                   >
-                                                                    <div
+                                                                    <StyledComponent
                                                                       active={0}
-                                                                      className="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "Link__BoxContainer-gur8v7-0",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "c14",
+                                                                            "rules": Array [
+                                                                              [Function],
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "Link__BoxContainer",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                                                          "target": [Function],
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
                                                                       submenulink={1}
+                                                                      vertical={3}
                                                                     >
-                                                                      <Link__BoxActive
+                                                                      <Box
                                                                         active={0}
-                                                                        horizontal={3}
+                                                                        className="c14"
+                                                                        inline={false}
                                                                         submenulink={1}
+                                                                        tag="div"
+                                                                        vertical={3}
                                                                       >
-                                                                        <StyledComponent
+                                                                        <div
                                                                           active={0}
-                                                                          forwardedComponent={
-                                                                            Object {
-                                                                              "$$typeof": Symbol(react.forward_ref),
-                                                                              "attrs": Array [],
-                                                                              "componentStyle": ComponentStyle {
-                                                                                "componentId": "Link__BoxActive-gur8v7-2",
-                                                                                "isStatic": false,
-                                                                                "lastClassName": "c14",
-                                                                                "rules": Array [
-                                                                                  [Function],
-                                                                                ],
-                                                                              },
-                                                                              "displayName": "Link__BoxActive",
-                                                                              "foldedComponentIds": Array [],
-                                                                              "render": [Function],
-                                                                              "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                                              "target": [Function],
-                                                                              "toString": [Function],
-                                                                              "warnTooManyClasses": [Function],
-                                                                              "withComponent": [Function],
-                                                                            }
-                                                                          }
-                                                                          forwardedRef={null}
-                                                                          horizontal={3}
+                                                                          className="TDS_Box-modules__verticalPadding-3___Fsv37 c14"
                                                                           submenulink={1}
                                                                         >
-                                                                          <Box
+                                                                          <Link__BoxActive
                                                                             active={0}
-                                                                            className="c14"
                                                                             horizontal={3}
-                                                                            inline={false}
                                                                             submenulink={1}
-                                                                            tag="div"
                                                                           >
-                                                                            <div
+                                                                            <StyledComponent
                                                                               active={0}
-                                                                              className="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
+                                                                              forwardedComponent={
+                                                                                Object {
+                                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                                  "attrs": Array [],
+                                                                                  "componentStyle": ComponentStyle {
+                                                                                    "componentId": "Link__BoxActive-gur8v7-2",
+                                                                                    "isStatic": false,
+                                                                                    "lastClassName": "c15",
+                                                                                    "rules": Array [
+                                                                                      [Function],
+                                                                                    ],
+                                                                                  },
+                                                                                  "displayName": "Link__BoxActive",
+                                                                                  "foldedComponentIds": Array [],
+                                                                                  "render": [Function],
+                                                                                  "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                                                  "target": [Function],
+                                                                                  "toString": [Function],
+                                                                                  "warnTooManyClasses": [Function],
+                                                                                  "withComponent": [Function],
+                                                                                }
+                                                                              }
+                                                                              forwardedRef={null}
+                                                                              horizontal={3}
                                                                               submenulink={1}
                                                                             >
-                                                                              <Link__StyledTextProvider
-                                                                                active={false}
+                                                                              <Box
+                                                                                active={0}
+                                                                                className="c15"
+                                                                                horizontal={3}
+                                                                                inline={false}
+                                                                                submenulink={1}
+                                                                                tag="div"
                                                                               >
-                                                                                <StyledComponent
-                                                                                  active={false}
-                                                                                  forwardedComponent={
-                                                                                    Object {
-                                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                                      "attrs": Array [],
-                                                                                      "componentStyle": ComponentStyle {
-                                                                                        "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                        "isStatic": false,
-                                                                                        "lastClassName": "c8",
-                                                                                        "rules": Array [
-                                                                                          [Function],
-                                                                                        ],
-                                                                                      },
-                                                                                      "displayName": "Link__StyledTextProvider",
-                                                                                      "foldedComponentIds": Array [],
-                                                                                      "render": [Function],
-                                                                                      "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                      "target": [Function],
-                                                                                      "toString": [Function],
-                                                                                      "warnTooManyClasses": [Function],
-                                                                                      "withComponent": [Function],
-                                                                                    }
-                                                                                  }
-                                                                                  forwardedRef={null}
+                                                                                <div
+                                                                                  active={0}
+                                                                                  className="TDS_Box-modules__horizontalPadding-3___2uoUp c15"
+                                                                                  submenulink={1}
                                                                                 >
-                                                                                  <ColoredTextProvider
+                                                                                  <Link__StyledTextProvider
                                                                                     active={false}
-                                                                                    className="c8"
                                                                                   >
-                                                                                    <div
-                                                                                      className="c8"
+                                                                                    <StyledComponent
+                                                                                      active={false}
+                                                                                      forwardedComponent={
+                                                                                        Object {
+                                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                                          "attrs": Array [],
+                                                                                          "componentStyle": ComponentStyle {
+                                                                                            "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                            "isStatic": false,
+                                                                                            "lastClassName": "c8",
+                                                                                            "rules": Array [
+                                                                                              [Function],
+                                                                                            ],
+                                                                                          },
+                                                                                          "displayName": "Link__StyledTextProvider",
+                                                                                          "foldedComponentIds": Array [],
+                                                                                          "render": [Function],
+                                                                                          "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                          "target": [Function],
+                                                                                          "toString": [Function],
+                                                                                          "warnTooManyClasses": [Function],
+                                                                                          "withComponent": [Function],
+                                                                                        }
+                                                                                      }
+                                                                                      forwardedRef={null}
                                                                                     >
-                                                                                      <Text
-                                                                                        block={false}
-                                                                                        bold={false}
-                                                                                        invert={false}
-                                                                                        size="small"
+                                                                                      <ColoredTextProvider
+                                                                                        active={false}
+                                                                                        className="c8"
                                                                                       >
-                                                                                        <Text__StyledText
-                                                                                          block={false}
-                                                                                          bold={false}
-                                                                                          inheritColor={true}
-                                                                                          invert={false}
-                                                                                          size="small"
+                                                                                        <div
+                                                                                          className="c8"
                                                                                         >
-                                                                                          <StyledComponent
+                                                                                          <Text
                                                                                             block={false}
                                                                                             bold={false}
-                                                                                            forwardedComponent={
-                                                                                              Object {
-                                                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                                                "attrs": Array [],
-                                                                                                "componentStyle": ComponentStyle {
-                                                                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                  "isStatic": false,
-                                                                                                  "lastClassName": "c15",
-                                                                                                  "rules": Array [
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                                                  ],
-                                                                                                },
-                                                                                                "displayName": "Text__StyledText",
-                                                                                                "foldedComponentIds": Array [],
-                                                                                                "render": [Function],
-                                                                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                "target": "span",
-                                                                                                "toString": [Function],
-                                                                                                "warnTooManyClasses": [Function],
-                                                                                                "withComponent": [Function],
-                                                                                              }
-                                                                                            }
-                                                                                            forwardedRef={null}
-                                                                                            inheritColor={true}
                                                                                             invert={false}
                                                                                             size="small"
                                                                                           >
-                                                                                            <span
-                                                                                              className="c15"
+                                                                                            <Text__StyledText
+                                                                                              block={false}
+                                                                                              bold={false}
+                                                                                              inheritColor={true}
+                                                                                              invert={false}
                                                                                               size="small"
                                                                                             >
-                                                                                              Option 1
-                                                                                            </span>
-                                                                                          </StyledComponent>
-                                                                                        </Text__StyledText>
-                                                                                      </Text>
-                                                                                    </div>
-                                                                                  </ColoredTextProvider>
-                                                                                </StyledComponent>
-                                                                              </Link__StyledTextProvider>
-                                                                            </div>
-                                                                          </Box>
-                                                                        </StyledComponent>
-                                                                      </Link__BoxActive>
-                                                                    </div>
-                                                                  </Box>
-                                                                </StyledComponent>
-                                                              </Link__BoxContainer>
-                                                            </div>
-                                                          </Box>
-                                                        </StyledComponent>
-                                                      </Link__BoxWrapper>
-                                                    </a>
-                                                  </StyledComponent>
-                                                </Link__StyledAnchor>
-                                              </Link>
-                                            </li>
-                                            <li
-                                              key=".1"
-                                            >
-                                              <Link
-                                                active={false}
-                                                href="#"
-                                                reactRouterLinkComponent={null}
-                                                subMenuLink={true}
-                                                to={null}
-                                              >
-                                                <Link__StyledAnchor
-                                                  href="#"
-                                                  to={null}
+                                                                                              <StyledComponent
+                                                                                                block={false}
+                                                                                                bold={false}
+                                                                                                forwardedComponent={
+                                                                                                  Object {
+                                                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                                                    "attrs": Array [],
+                                                                                                    "componentStyle": ComponentStyle {
+                                                                                                      "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                      "isStatic": false,
+                                                                                                      "lastClassName": "c16",
+                                                                                                      "rules": Array [
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                                                      ],
+                                                                                                    },
+                                                                                                    "displayName": "Text__StyledText",
+                                                                                                    "foldedComponentIds": Array [],
+                                                                                                    "render": [Function],
+                                                                                                    "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                    "target": "span",
+                                                                                                    "toString": [Function],
+                                                                                                    "warnTooManyClasses": [Function],
+                                                                                                    "withComponent": [Function],
+                                                                                                  }
+                                                                                                }
+                                                                                                forwardedRef={null}
+                                                                                                inheritColor={true}
+                                                                                                invert={false}
+                                                                                                size="small"
+                                                                                              >
+                                                                                                <span
+                                                                                                  className="c16"
+                                                                                                  size="small"
+                                                                                                >
+                                                                                                  Option 1
+                                                                                                </span>
+                                                                                              </StyledComponent>
+                                                                                            </Text__StyledText>
+                                                                                          </Text>
+                                                                                        </div>
+                                                                                      </ColoredTextProvider>
+                                                                                    </StyledComponent>
+                                                                                  </Link__StyledTextProvider>
+                                                                                </div>
+                                                                              </Box>
+                                                                            </StyledComponent>
+                                                                          </Link__BoxActive>
+                                                                        </div>
+                                                                      </Box>
+                                                                    </StyledComponent>
+                                                                  </Link__BoxContainer>
+                                                                </div>
+                                                              </Box>
+                                                            </StyledComponent>
+                                                          </Link__BoxWrapper>
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </Link__StyledAnchor>
+                                                  </Link>
+                                                </li>
+                                                <li
+                                                  key=".1"
                                                 >
-                                                  <StyledComponent
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledAnchor-gur8v7-4",
-                                                          "isStatic": true,
-                                                          "lastClassName": "c4",
-                                                          "rules": Array [
-                                                            "text-decoration: none;",
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledAnchor",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <Link
+                                                    active={false}
                                                     href="#"
+                                                    reactRouterLinkComponent={null}
+                                                    subMenuLink={true}
                                                     to={null}
                                                   >
-                                                    <a
-                                                      className="c4"
+                                                    <Link__StyledAnchor
                                                       href="#"
                                                       to={null}
                                                     >
-                                                      <Link__BoxWrapper
-                                                        active={0}
-                                                      >
-                                                        <StyledComponent
-                                                          active={0}
-                                                          forwardedComponent={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "attrs": Array [],
-                                                              "componentStyle": ComponentStyle {
-                                                                "componentId": "Link__BoxWrapper-gur8v7-1",
-                                                                "isStatic": false,
-                                                                "lastClassName": "c5",
-                                                                "rules": Array [
-                                                                  [Function],
-                                                                ],
-                                                              },
-                                                              "displayName": "Link__BoxWrapper",
-                                                              "foldedComponentIds": Array [],
-                                                              "render": [Function],
-                                                              "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                                              "target": [Function],
-                                                              "toString": [Function],
-                                                              "warnTooManyClasses": [Function],
-                                                              "withComponent": [Function],
-                                                            }
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledAnchor-gur8v7-4",
+                                                              "isStatic": true,
+                                                              "lastClassName": "c4",
+                                                              "rules": Array [
+                                                                "text-decoration: none;",
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledAnchor",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
                                                           }
-                                                          forwardedRef={null}
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="#"
+                                                        to={null}
+                                                      >
+                                                        <a
+                                                          className="c4"
+                                                          href="#"
+                                                          to={null}
                                                         >
-                                                          <Box
+                                                          <Link__BoxWrapper
                                                             active={0}
-                                                            className="c5"
-                                                            inline={false}
-                                                            tag="div"
                                                           >
-                                                            <div
+                                                            <StyledComponent
                                                               active={0}
-                                                              className="c5"
+                                                              forwardedComponent={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "attrs": Array [],
+                                                                  "componentStyle": ComponentStyle {
+                                                                    "componentId": "Link__BoxWrapper-gur8v7-1",
+                                                                    "isStatic": false,
+                                                                    "lastClassName": "c5",
+                                                                    "rules": Array [
+                                                                      [Function],
+                                                                    ],
+                                                                  },
+                                                                  "displayName": "Link__BoxWrapper",
+                                                                  "foldedComponentIds": Array [],
+                                                                  "render": [Function],
+                                                                  "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                                                  "target": [Function],
+                                                                  "toString": [Function],
+                                                                  "warnTooManyClasses": [Function],
+                                                                  "withComponent": [Function],
+                                                                }
+                                                              }
+                                                              forwardedRef={null}
                                                             >
-                                                              <Link__BoxContainer
+                                                              <Box
                                                                 active={0}
-                                                                submenulink={1}
-                                                                vertical={3}
+                                                                className="c5"
+                                                                inline={false}
+                                                                tag="div"
                                                               >
-                                                                <StyledComponent
+                                                                <div
                                                                   active={0}
-                                                                  forwardedComponent={
-                                                                    Object {
-                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                      "attrs": Array [],
-                                                                      "componentStyle": ComponentStyle {
-                                                                        "componentId": "Link__BoxContainer-gur8v7-0",
-                                                                        "isStatic": false,
-                                                                        "lastClassName": "c13",
-                                                                        "rules": Array [
-                                                                          [Function],
-                                                                        ],
-                                                                      },
-                                                                      "displayName": "Link__BoxContainer",
-                                                                      "foldedComponentIds": Array [],
-                                                                      "render": [Function],
-                                                                      "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                                                      "target": [Function],
-                                                                      "toString": [Function],
-                                                                      "warnTooManyClasses": [Function],
-                                                                      "withComponent": [Function],
-                                                                    }
-                                                                  }
-                                                                  forwardedRef={null}
-                                                                  submenulink={1}
-                                                                  vertical={3}
+                                                                  className="c5"
                                                                 >
-                                                                  <Box
+                                                                  <Link__BoxContainer
                                                                     active={0}
-                                                                    className="c13"
-                                                                    inline={false}
                                                                     submenulink={1}
-                                                                    tag="div"
                                                                     vertical={3}
                                                                   >
-                                                                    <div
+                                                                    <StyledComponent
                                                                       active={0}
-                                                                      className="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "Link__BoxContainer-gur8v7-0",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "c14",
+                                                                            "rules": Array [
+                                                                              [Function],
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "Link__BoxContainer",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                                                          "target": [Function],
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
                                                                       submenulink={1}
+                                                                      vertical={3}
                                                                     >
-                                                                      <Link__BoxActive
+                                                                      <Box
                                                                         active={0}
-                                                                        horizontal={3}
+                                                                        className="c14"
+                                                                        inline={false}
                                                                         submenulink={1}
+                                                                        tag="div"
+                                                                        vertical={3}
                                                                       >
-                                                                        <StyledComponent
+                                                                        <div
                                                                           active={0}
-                                                                          forwardedComponent={
-                                                                            Object {
-                                                                              "$$typeof": Symbol(react.forward_ref),
-                                                                              "attrs": Array [],
-                                                                              "componentStyle": ComponentStyle {
-                                                                                "componentId": "Link__BoxActive-gur8v7-2",
-                                                                                "isStatic": false,
-                                                                                "lastClassName": "c14",
-                                                                                "rules": Array [
-                                                                                  [Function],
-                                                                                ],
-                                                                              },
-                                                                              "displayName": "Link__BoxActive",
-                                                                              "foldedComponentIds": Array [],
-                                                                              "render": [Function],
-                                                                              "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                                              "target": [Function],
-                                                                              "toString": [Function],
-                                                                              "warnTooManyClasses": [Function],
-                                                                              "withComponent": [Function],
-                                                                            }
-                                                                          }
-                                                                          forwardedRef={null}
-                                                                          horizontal={3}
+                                                                          className="TDS_Box-modules__verticalPadding-3___Fsv37 c14"
                                                                           submenulink={1}
                                                                         >
-                                                                          <Box
+                                                                          <Link__BoxActive
                                                                             active={0}
-                                                                            className="c14"
                                                                             horizontal={3}
-                                                                            inline={false}
                                                                             submenulink={1}
-                                                                            tag="div"
                                                                           >
-                                                                            <div
+                                                                            <StyledComponent
                                                                               active={0}
-                                                                              className="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
+                                                                              forwardedComponent={
+                                                                                Object {
+                                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                                  "attrs": Array [],
+                                                                                  "componentStyle": ComponentStyle {
+                                                                                    "componentId": "Link__BoxActive-gur8v7-2",
+                                                                                    "isStatic": false,
+                                                                                    "lastClassName": "c15",
+                                                                                    "rules": Array [
+                                                                                      [Function],
+                                                                                    ],
+                                                                                  },
+                                                                                  "displayName": "Link__BoxActive",
+                                                                                  "foldedComponentIds": Array [],
+                                                                                  "render": [Function],
+                                                                                  "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                                                  "target": [Function],
+                                                                                  "toString": [Function],
+                                                                                  "warnTooManyClasses": [Function],
+                                                                                  "withComponent": [Function],
+                                                                                }
+                                                                              }
+                                                                              forwardedRef={null}
+                                                                              horizontal={3}
                                                                               submenulink={1}
                                                                             >
-                                                                              <Link__StyledTextProvider
-                                                                                active={false}
+                                                                              <Box
+                                                                                active={0}
+                                                                                className="c15"
+                                                                                horizontal={3}
+                                                                                inline={false}
+                                                                                submenulink={1}
+                                                                                tag="div"
                                                                               >
-                                                                                <StyledComponent
-                                                                                  active={false}
-                                                                                  forwardedComponent={
-                                                                                    Object {
-                                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                                      "attrs": Array [],
-                                                                                      "componentStyle": ComponentStyle {
-                                                                                        "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                        "isStatic": false,
-                                                                                        "lastClassName": "c8",
-                                                                                        "rules": Array [
-                                                                                          [Function],
-                                                                                        ],
-                                                                                      },
-                                                                                      "displayName": "Link__StyledTextProvider",
-                                                                                      "foldedComponentIds": Array [],
-                                                                                      "render": [Function],
-                                                                                      "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                      "target": [Function],
-                                                                                      "toString": [Function],
-                                                                                      "warnTooManyClasses": [Function],
-                                                                                      "withComponent": [Function],
-                                                                                    }
-                                                                                  }
-                                                                                  forwardedRef={null}
+                                                                                <div
+                                                                                  active={0}
+                                                                                  className="TDS_Box-modules__horizontalPadding-3___2uoUp c15"
+                                                                                  submenulink={1}
                                                                                 >
-                                                                                  <ColoredTextProvider
+                                                                                  <Link__StyledTextProvider
                                                                                     active={false}
-                                                                                    className="c8"
                                                                                   >
-                                                                                    <div
-                                                                                      className="c8"
+                                                                                    <StyledComponent
+                                                                                      active={false}
+                                                                                      forwardedComponent={
+                                                                                        Object {
+                                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                                          "attrs": Array [],
+                                                                                          "componentStyle": ComponentStyle {
+                                                                                            "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                            "isStatic": false,
+                                                                                            "lastClassName": "c8",
+                                                                                            "rules": Array [
+                                                                                              [Function],
+                                                                                            ],
+                                                                                          },
+                                                                                          "displayName": "Link__StyledTextProvider",
+                                                                                          "foldedComponentIds": Array [],
+                                                                                          "render": [Function],
+                                                                                          "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                          "target": [Function],
+                                                                                          "toString": [Function],
+                                                                                          "warnTooManyClasses": [Function],
+                                                                                          "withComponent": [Function],
+                                                                                        }
+                                                                                      }
+                                                                                      forwardedRef={null}
                                                                                     >
-                                                                                      <Text
-                                                                                        block={false}
-                                                                                        bold={false}
-                                                                                        invert={false}
-                                                                                        size="small"
+                                                                                      <ColoredTextProvider
+                                                                                        active={false}
+                                                                                        className="c8"
                                                                                       >
-                                                                                        <Text__StyledText
-                                                                                          block={false}
-                                                                                          bold={false}
-                                                                                          inheritColor={true}
-                                                                                          invert={false}
-                                                                                          size="small"
+                                                                                        <div
+                                                                                          className="c8"
                                                                                         >
-                                                                                          <StyledComponent
+                                                                                          <Text
                                                                                             block={false}
                                                                                             bold={false}
-                                                                                            forwardedComponent={
-                                                                                              Object {
-                                                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                                                "attrs": Array [],
-                                                                                                "componentStyle": ComponentStyle {
-                                                                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                  "isStatic": false,
-                                                                                                  "lastClassName": "c15",
-                                                                                                  "rules": Array [
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                                                  ],
-                                                                                                },
-                                                                                                "displayName": "Text__StyledText",
-                                                                                                "foldedComponentIds": Array [],
-                                                                                                "render": [Function],
-                                                                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                "target": "span",
-                                                                                                "toString": [Function],
-                                                                                                "warnTooManyClasses": [Function],
-                                                                                                "withComponent": [Function],
-                                                                                              }
-                                                                                            }
-                                                                                            forwardedRef={null}
-                                                                                            inheritColor={true}
                                                                                             invert={false}
                                                                                             size="small"
                                                                                           >
-                                                                                            <span
-                                                                                              className="c15"
+                                                                                            <Text__StyledText
+                                                                                              block={false}
+                                                                                              bold={false}
+                                                                                              inheritColor={true}
+                                                                                              invert={false}
                                                                                               size="small"
                                                                                             >
-                                                                                              Option 2
-                                                                                            </span>
-                                                                                          </StyledComponent>
-                                                                                        </Text__StyledText>
-                                                                                      </Text>
-                                                                                    </div>
-                                                                                  </ColoredTextProvider>
-                                                                                </StyledComponent>
-                                                                              </Link__StyledTextProvider>
-                                                                            </div>
-                                                                          </Box>
-                                                                        </StyledComponent>
-                                                                      </Link__BoxActive>
-                                                                    </div>
-                                                                  </Box>
-                                                                </StyledComponent>
-                                                              </Link__BoxContainer>
-                                                            </div>
-                                                          </Box>
-                                                        </StyledComponent>
-                                                      </Link__BoxWrapper>
-                                                    </a>
-                                                  </StyledComponent>
-                                                </Link__StyledAnchor>
-                                              </Link>
-                                            </li>
-                                            <li
-                                              key=".2"
-                                            >
-                                              <Link
-                                                active={false}
-                                                href="#"
-                                                reactRouterLinkComponent={null}
-                                                subMenuLink={true}
-                                                to={null}
-                                              >
-                                                <Link__StyledAnchor
-                                                  href="#"
-                                                  to={null}
+                                                                                              <StyledComponent
+                                                                                                block={false}
+                                                                                                bold={false}
+                                                                                                forwardedComponent={
+                                                                                                  Object {
+                                                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                                                    "attrs": Array [],
+                                                                                                    "componentStyle": ComponentStyle {
+                                                                                                      "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                      "isStatic": false,
+                                                                                                      "lastClassName": "c16",
+                                                                                                      "rules": Array [
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                                                      ],
+                                                                                                    },
+                                                                                                    "displayName": "Text__StyledText",
+                                                                                                    "foldedComponentIds": Array [],
+                                                                                                    "render": [Function],
+                                                                                                    "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                    "target": "span",
+                                                                                                    "toString": [Function],
+                                                                                                    "warnTooManyClasses": [Function],
+                                                                                                    "withComponent": [Function],
+                                                                                                  }
+                                                                                                }
+                                                                                                forwardedRef={null}
+                                                                                                inheritColor={true}
+                                                                                                invert={false}
+                                                                                                size="small"
+                                                                                              >
+                                                                                                <span
+                                                                                                  className="c16"
+                                                                                                  size="small"
+                                                                                                >
+                                                                                                  Option 2
+                                                                                                </span>
+                                                                                              </StyledComponent>
+                                                                                            </Text__StyledText>
+                                                                                          </Text>
+                                                                                        </div>
+                                                                                      </ColoredTextProvider>
+                                                                                    </StyledComponent>
+                                                                                  </Link__StyledTextProvider>
+                                                                                </div>
+                                                                              </Box>
+                                                                            </StyledComponent>
+                                                                          </Link__BoxActive>
+                                                                        </div>
+                                                                      </Box>
+                                                                    </StyledComponent>
+                                                                  </Link__BoxContainer>
+                                                                </div>
+                                                              </Box>
+                                                            </StyledComponent>
+                                                          </Link__BoxWrapper>
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </Link__StyledAnchor>
+                                                  </Link>
+                                                </li>
+                                                <li
+                                                  key=".2"
                                                 >
-                                                  <StyledComponent
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledAnchor-gur8v7-4",
-                                                          "isStatic": true,
-                                                          "lastClassName": "c4",
-                                                          "rules": Array [
-                                                            "text-decoration: none;",
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledAnchor",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <Link
+                                                    active={false}
                                                     href="#"
+                                                    reactRouterLinkComponent={null}
+                                                    subMenuLink={true}
                                                     to={null}
                                                   >
-                                                    <a
-                                                      className="c4"
+                                                    <Link__StyledAnchor
                                                       href="#"
                                                       to={null}
                                                     >
-                                                      <Link__BoxWrapper
-                                                        active={0}
-                                                      >
-                                                        <StyledComponent
-                                                          active={0}
-                                                          forwardedComponent={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "attrs": Array [],
-                                                              "componentStyle": ComponentStyle {
-                                                                "componentId": "Link__BoxWrapper-gur8v7-1",
-                                                                "isStatic": false,
-                                                                "lastClassName": "c5",
-                                                                "rules": Array [
-                                                                  [Function],
-                                                                ],
-                                                              },
-                                                              "displayName": "Link__BoxWrapper",
-                                                              "foldedComponentIds": Array [],
-                                                              "render": [Function],
-                                                              "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                                              "target": [Function],
-                                                              "toString": [Function],
-                                                              "warnTooManyClasses": [Function],
-                                                              "withComponent": [Function],
-                                                            }
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledAnchor-gur8v7-4",
+                                                              "isStatic": true,
+                                                              "lastClassName": "c4",
+                                                              "rules": Array [
+                                                                "text-decoration: none;",
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledAnchor",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
                                                           }
-                                                          forwardedRef={null}
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="#"
+                                                        to={null}
+                                                      >
+                                                        <a
+                                                          className="c4"
+                                                          href="#"
+                                                          to={null}
                                                         >
-                                                          <Box
+                                                          <Link__BoxWrapper
                                                             active={0}
-                                                            className="c5"
-                                                            inline={false}
-                                                            tag="div"
                                                           >
-                                                            <div
+                                                            <StyledComponent
                                                               active={0}
-                                                              className="c5"
+                                                              forwardedComponent={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "attrs": Array [],
+                                                                  "componentStyle": ComponentStyle {
+                                                                    "componentId": "Link__BoxWrapper-gur8v7-1",
+                                                                    "isStatic": false,
+                                                                    "lastClassName": "c5",
+                                                                    "rules": Array [
+                                                                      [Function],
+                                                                    ],
+                                                                  },
+                                                                  "displayName": "Link__BoxWrapper",
+                                                                  "foldedComponentIds": Array [],
+                                                                  "render": [Function],
+                                                                  "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                                                  "target": [Function],
+                                                                  "toString": [Function],
+                                                                  "warnTooManyClasses": [Function],
+                                                                  "withComponent": [Function],
+                                                                }
+                                                              }
+                                                              forwardedRef={null}
                                                             >
-                                                              <Link__BoxContainer
+                                                              <Box
                                                                 active={0}
-                                                                submenulink={1}
-                                                                vertical={3}
+                                                                className="c5"
+                                                                inline={false}
+                                                                tag="div"
                                                               >
-                                                                <StyledComponent
+                                                                <div
                                                                   active={0}
-                                                                  forwardedComponent={
-                                                                    Object {
-                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                      "attrs": Array [],
-                                                                      "componentStyle": ComponentStyle {
-                                                                        "componentId": "Link__BoxContainer-gur8v7-0",
-                                                                        "isStatic": false,
-                                                                        "lastClassName": "c13",
-                                                                        "rules": Array [
-                                                                          [Function],
-                                                                        ],
-                                                                      },
-                                                                      "displayName": "Link__BoxContainer",
-                                                                      "foldedComponentIds": Array [],
-                                                                      "render": [Function],
-                                                                      "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                                                      "target": [Function],
-                                                                      "toString": [Function],
-                                                                      "warnTooManyClasses": [Function],
-                                                                      "withComponent": [Function],
-                                                                    }
-                                                                  }
-                                                                  forwardedRef={null}
-                                                                  submenulink={1}
-                                                                  vertical={3}
+                                                                  className="c5"
                                                                 >
-                                                                  <Box
+                                                                  <Link__BoxContainer
                                                                     active={0}
-                                                                    className="c13"
-                                                                    inline={false}
                                                                     submenulink={1}
-                                                                    tag="div"
                                                                     vertical={3}
                                                                   >
-                                                                    <div
+                                                                    <StyledComponent
                                                                       active={0}
-                                                                      className="TDS_Box-modules__verticalPadding-3___Fsv37 c13"
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "Link__BoxContainer-gur8v7-0",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "c14",
+                                                                            "rules": Array [
+                                                                              [Function],
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "Link__BoxContainer",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                                                          "target": [Function],
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
                                                                       submenulink={1}
+                                                                      vertical={3}
                                                                     >
-                                                                      <Link__BoxActive
+                                                                      <Box
                                                                         active={0}
-                                                                        horizontal={3}
+                                                                        className="c14"
+                                                                        inline={false}
                                                                         submenulink={1}
+                                                                        tag="div"
+                                                                        vertical={3}
                                                                       >
-                                                                        <StyledComponent
+                                                                        <div
                                                                           active={0}
-                                                                          forwardedComponent={
-                                                                            Object {
-                                                                              "$$typeof": Symbol(react.forward_ref),
-                                                                              "attrs": Array [],
-                                                                              "componentStyle": ComponentStyle {
-                                                                                "componentId": "Link__BoxActive-gur8v7-2",
-                                                                                "isStatic": false,
-                                                                                "lastClassName": "c14",
-                                                                                "rules": Array [
-                                                                                  [Function],
-                                                                                ],
-                                                                              },
-                                                                              "displayName": "Link__BoxActive",
-                                                                              "foldedComponentIds": Array [],
-                                                                              "render": [Function],
-                                                                              "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                                              "target": [Function],
-                                                                              "toString": [Function],
-                                                                              "warnTooManyClasses": [Function],
-                                                                              "withComponent": [Function],
-                                                                            }
-                                                                          }
-                                                                          forwardedRef={null}
-                                                                          horizontal={3}
+                                                                          className="TDS_Box-modules__verticalPadding-3___Fsv37 c14"
                                                                           submenulink={1}
                                                                         >
-                                                                          <Box
+                                                                          <Link__BoxActive
                                                                             active={0}
-                                                                            className="c14"
                                                                             horizontal={3}
-                                                                            inline={false}
                                                                             submenulink={1}
-                                                                            tag="div"
                                                                           >
-                                                                            <div
+                                                                            <StyledComponent
                                                                               active={0}
-                                                                              className="TDS_Box-modules__horizontalPadding-3___2uoUp c14"
+                                                                              forwardedComponent={
+                                                                                Object {
+                                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                                  "attrs": Array [],
+                                                                                  "componentStyle": ComponentStyle {
+                                                                                    "componentId": "Link__BoxActive-gur8v7-2",
+                                                                                    "isStatic": false,
+                                                                                    "lastClassName": "c15",
+                                                                                    "rules": Array [
+                                                                                      [Function],
+                                                                                    ],
+                                                                                  },
+                                                                                  "displayName": "Link__BoxActive",
+                                                                                  "foldedComponentIds": Array [],
+                                                                                  "render": [Function],
+                                                                                  "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                                                  "target": [Function],
+                                                                                  "toString": [Function],
+                                                                                  "warnTooManyClasses": [Function],
+                                                                                  "withComponent": [Function],
+                                                                                }
+                                                                              }
+                                                                              forwardedRef={null}
+                                                                              horizontal={3}
                                                                               submenulink={1}
                                                                             >
-                                                                              <Link__StyledTextProvider
-                                                                                active={false}
+                                                                              <Box
+                                                                                active={0}
+                                                                                className="c15"
+                                                                                horizontal={3}
+                                                                                inline={false}
+                                                                                submenulink={1}
+                                                                                tag="div"
                                                                               >
-                                                                                <StyledComponent
-                                                                                  active={false}
-                                                                                  forwardedComponent={
-                                                                                    Object {
-                                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                                      "attrs": Array [],
-                                                                                      "componentStyle": ComponentStyle {
-                                                                                        "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                        "isStatic": false,
-                                                                                        "lastClassName": "c8",
-                                                                                        "rules": Array [
-                                                                                          [Function],
-                                                                                        ],
-                                                                                      },
-                                                                                      "displayName": "Link__StyledTextProvider",
-                                                                                      "foldedComponentIds": Array [],
-                                                                                      "render": [Function],
-                                                                                      "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                      "target": [Function],
-                                                                                      "toString": [Function],
-                                                                                      "warnTooManyClasses": [Function],
-                                                                                      "withComponent": [Function],
-                                                                                    }
-                                                                                  }
-                                                                                  forwardedRef={null}
+                                                                                <div
+                                                                                  active={0}
+                                                                                  className="TDS_Box-modules__horizontalPadding-3___2uoUp c15"
+                                                                                  submenulink={1}
                                                                                 >
-                                                                                  <ColoredTextProvider
+                                                                                  <Link__StyledTextProvider
                                                                                     active={false}
-                                                                                    className="c8"
                                                                                   >
-                                                                                    <div
-                                                                                      className="c8"
+                                                                                    <StyledComponent
+                                                                                      active={false}
+                                                                                      forwardedComponent={
+                                                                                        Object {
+                                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                                          "attrs": Array [],
+                                                                                          "componentStyle": ComponentStyle {
+                                                                                            "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                            "isStatic": false,
+                                                                                            "lastClassName": "c8",
+                                                                                            "rules": Array [
+                                                                                              [Function],
+                                                                                            ],
+                                                                                          },
+                                                                                          "displayName": "Link__StyledTextProvider",
+                                                                                          "foldedComponentIds": Array [],
+                                                                                          "render": [Function],
+                                                                                          "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                          "target": [Function],
+                                                                                          "toString": [Function],
+                                                                                          "warnTooManyClasses": [Function],
+                                                                                          "withComponent": [Function],
+                                                                                        }
+                                                                                      }
+                                                                                      forwardedRef={null}
                                                                                     >
-                                                                                      <Text
-                                                                                        block={false}
-                                                                                        bold={false}
-                                                                                        invert={false}
-                                                                                        size="small"
+                                                                                      <ColoredTextProvider
+                                                                                        active={false}
+                                                                                        className="c8"
                                                                                       >
-                                                                                        <Text__StyledText
-                                                                                          block={false}
-                                                                                          bold={false}
-                                                                                          inheritColor={true}
-                                                                                          invert={false}
-                                                                                          size="small"
+                                                                                        <div
+                                                                                          className="c8"
                                                                                         >
-                                                                                          <StyledComponent
+                                                                                          <Text
                                                                                             block={false}
                                                                                             bold={false}
-                                                                                            forwardedComponent={
-                                                                                              Object {
-                                                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                                                "attrs": Array [],
-                                                                                                "componentStyle": ComponentStyle {
-                                                                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                  "isStatic": false,
-                                                                                                  "lastClassName": "c15",
-                                                                                                  "rules": Array [
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                                                  ],
-                                                                                                },
-                                                                                                "displayName": "Text__StyledText",
-                                                                                                "foldedComponentIds": Array [],
-                                                                                                "render": [Function],
-                                                                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                "target": "span",
-                                                                                                "toString": [Function],
-                                                                                                "warnTooManyClasses": [Function],
-                                                                                                "withComponent": [Function],
-                                                                                              }
-                                                                                            }
-                                                                                            forwardedRef={null}
-                                                                                            inheritColor={true}
                                                                                             invert={false}
                                                                                             size="small"
                                                                                           >
-                                                                                            <span
-                                                                                              className="c15"
+                                                                                            <Text__StyledText
+                                                                                              block={false}
+                                                                                              bold={false}
+                                                                                              inheritColor={true}
+                                                                                              invert={false}
                                                                                               size="small"
                                                                                             >
-                                                                                              Option 3
-                                                                                            </span>
-                                                                                          </StyledComponent>
-                                                                                        </Text__StyledText>
-                                                                                      </Text>
-                                                                                    </div>
-                                                                                  </ColoredTextProvider>
-                                                                                </StyledComponent>
-                                                                              </Link__StyledTextProvider>
-                                                                            </div>
-                                                                          </Box>
-                                                                        </StyledComponent>
-                                                                      </Link__BoxActive>
-                                                                    </div>
-                                                                  </Box>
-                                                                </StyledComponent>
-                                                              </Link__BoxContainer>
-                                                            </div>
-                                                          </Box>
-                                                        </StyledComponent>
-                                                      </Link__BoxWrapper>
-                                                    </a>
-                                                  </StyledComponent>
-                                                </Link__StyledAnchor>
-                                              </Link>
-                                            </li>
-                                          </ul>
-                                        </StyledComponent>
-                                      </SubMenu__SubMenuContainer>
-                                    </div>
+                                                                                              <StyledComponent
+                                                                                                block={false}
+                                                                                                bold={false}
+                                                                                                forwardedComponent={
+                                                                                                  Object {
+                                                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                                                    "attrs": Array [],
+                                                                                                    "componentStyle": ComponentStyle {
+                                                                                                      "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                      "isStatic": false,
+                                                                                                      "lastClassName": "c16",
+                                                                                                      "rules": Array [
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                                                      ],
+                                                                                                    },
+                                                                                                    "displayName": "Text__StyledText",
+                                                                                                    "foldedComponentIds": Array [],
+                                                                                                    "render": [Function],
+                                                                                                    "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                    "target": "span",
+                                                                                                    "toString": [Function],
+                                                                                                    "warnTooManyClasses": [Function],
+                                                                                                    "withComponent": [Function],
+                                                                                                  }
+                                                                                                }
+                                                                                                forwardedRef={null}
+                                                                                                inheritColor={true}
+                                                                                                invert={false}
+                                                                                                size="small"
+                                                                                              >
+                                                                                                <span
+                                                                                                  className="c16"
+                                                                                                  size="small"
+                                                                                                >
+                                                                                                  Option 3
+                                                                                                </span>
+                                                                                              </StyledComponent>
+                                                                                            </Text__StyledText>
+                                                                                          </Text>
+                                                                                        </div>
+                                                                                      </ColoredTextProvider>
+                                                                                    </StyledComponent>
+                                                                                  </Link__StyledTextProvider>
+                                                                                </div>
+                                                                              </Box>
+                                                                            </StyledComponent>
+                                                                          </Link__BoxActive>
+                                                                        </div>
+                                                                      </Box>
+                                                                    </StyledComponent>
+                                                                  </Link__BoxContainer>
+                                                                </div>
+                                                              </Box>
+                                                            </StyledComponent>
+                                                          </Link__BoxWrapper>
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </Link__StyledAnchor>
+                                                  </Link>
+                                                </li>
+                                              </ul>
+                                            </StyledComponent>
+                                          </SubMenu__SubMenuContainer>
+                                        </div>
+                                      </StyledComponent>
+                                    </FadeAndReveal__StyledContainer>
                                   </Transition>
-                                </Reveal>
+                                </FadeAndReveal>
                               </SubMenu>
                             </li>
                           </StyledComponent>
@@ -2843,7 +2911,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   padding-left: 0.1em;
 }
 
-.c18 {
+.c19 {
   color: #2a2c2e;
   color: inherit;
   word-wrap: break-word;
@@ -2857,7 +2925,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   font-weight: 700;
 }
 
-.c18 sup {
+.c19 sup {
   top: -0.5em;
   font-size: 0.875rem;
   position: relative;
@@ -2896,12 +2964,12 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   background-color: #f2eff4;
 }
 
-.c15 {
+.c16 {
   margin-left: 1rem;
   border-left: 4px solid #f2eff4;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: #f2eff4;
 }
 
@@ -2909,7 +2977,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   background-color: none;
 }
 
-.c14 {
+.c15 {
   background-color: #f2eff4;
 }
 
@@ -2918,7 +2986,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   margin-left: 0px;
 }
 
-.c16 {
+.c17 {
   border-left: 4px solid #4b286d;
   margin-left: -0.25rem;
 }
@@ -2931,7 +2999,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   color: #4b286d;
 }
 
-.c17 {
+.c18 {
   font-weight: bold;
   color: #4b286d;
 }
@@ -2941,7 +3009,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   text-decoration: none;
 }
 
-.c13 {
+.c14 {
   margin-bottom: 1rem;
 }
 
@@ -3012,6 +3080,13 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   -ms-flex-align: center;
   align-items: center;
   line-height: 0;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c13 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
 }
 
 <SideNavigation
@@ -3095,7 +3170,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   padding-left: 0.1em;
 }
 
-.c17 {
+.c18 {
   color: #2a2c2e;
   color: inherit;
   word-wrap: break-word;
@@ -3109,7 +3184,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   font-weight: 700;
 }
 
-.c17 sup {
+.c18 sup {
   top: -0.5em;
   font-size: 0.875rem;
   position: relative;
@@ -3148,12 +3223,12 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   background-color: #f2eff4;
 }
 
-.c14 {
+.c15 {
   margin-left: 1rem;
   border-left: 4px solid #f2eff4;
 }
 
-.c14:hover {
+.c15:hover {
   background-color: #f2eff4;
 }
 
@@ -3161,7 +3236,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   background-color: none;
 }
 
-.c13 {
+.c14 {
   background-color: #f2eff4;
 }
 
@@ -3170,7 +3245,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   margin-left: 0px;
 }
 
-.c15 {
+.c16 {
   border-left: 4px solid #4b286d;
   margin-left: -0.25rem;
 }
@@ -3183,7 +3258,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   color: #4b286d;
 }
 
-.c16 {
+.c17 {
   font-weight: bold;
   color: #4b286d;
 }
@@ -3193,7 +3268,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   text-decoration: none;
 }
 
-.c12 {
+.c13 {
   margin-bottom: 1rem;
 }
 
@@ -3259,6 +3334,13 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
   -ms-flex-align: center;
   align-items: center;
   line-height: 0;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c12 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
 }
 
 <div
@@ -3332,11 +3414,11 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                         </button>
                         <div
                           aria-hidden="false"
-                          data-testid="childrenContainer"
-                          style="transition: height 500ms; height: 0px; overflow: hidden;"
+                          class="c12"
+                          style="transition: height 500ms, opacity 500ms ease-in-out; opacity: 1; height: 0px; overflow: hidden;"
                         >
                           <ul
-                            class="c12"
+                            class="c13"
                           >
                             <li>
                               <a
@@ -3345,23 +3427,23 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                               >
                                 <div
                                   active="1"
-                                  class="c13"
+                                  class="c14"
                                 >
                                   <div
                                     active="1"
-                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c14"
+                                    class="TDS_Box-modules__verticalPadding-3___Fsv37 c15"
                                     submenulink="1"
                                   >
                                     <div
                                       active="1"
-                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c15"
+                                      class="TDS_Box-modules__horizontalPadding-3___2uoUp c16"
                                       submenulink="1"
                                     >
                                       <div
-                                        class="c16"
+                                        class="c17"
                                       >
                                         <span
-                                          class="c17"
+                                          class="c18"
                                         >
                                           Option 1
                                         </span>
@@ -3506,7 +3588,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "Link__BoxWrapper-gur8v7-1",
                                                 "isStatic": false,
-                                                "lastClassName": "c14",
+                                                "lastClassName": "c15",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -3547,7 +3629,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                                       "componentStyle": ComponentStyle {
                                                         "componentId": "Link__BoxContainer-gur8v7-0",
                                                         "isStatic": false,
-                                                        "lastClassName": "c15",
+                                                        "lastClassName": "c16",
                                                         "rules": Array [
                                                           [Function],
                                                         ],
@@ -3593,7 +3675,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                                               "componentStyle": ComponentStyle {
                                                                 "componentId": "Link__BoxActive-gur8v7-2",
                                                                 "isStatic": false,
-                                                                "lastClassName": "c16",
+                                                                "lastClassName": "c17",
                                                                 "rules": Array [
                                                                   [Function],
                                                                 ],
@@ -3637,7 +3719,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                                                       "componentStyle": ComponentStyle {
                                                                         "componentId": "Link__StyledTextProvider-gur8v7-3",
                                                                         "isStatic": false,
-                                                                        "lastClassName": "c17",
+                                                                        "lastClassName": "c18",
                                                                         "rules": Array [
                                                                           [Function],
                                                                         ],
@@ -3684,7 +3766,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                                                                 "componentStyle": ComponentStyle {
                                                                                   "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                                                   "isStatic": false,
-                                                                                  "lastClassName": "c18",
+                                                                                  "lastClassName": "c19",
                                                                                   "rules": Array [
                                                                                     [Function],
                                                                                     [Function],
@@ -3780,6 +3862,8 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                 isOpen={true}
                                 label="Threefdsfdsfds"
                                 onClick={[Function]}
+                                onExit={[Function]}
+                                onOpen={[Function]}
                               >
                                 <SubMenu__ButtonSubMenu
                                   active={true}
@@ -3896,7 +3980,7 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                                             "componentStyle": ComponentStyle {
                                                               "componentId": "Text__StyledText-sc-1m0rr67-0",
                                                               "isStatic": false,
-                                                              "lastClassName": "c18",
+                                                              "lastClassName": "c19",
                                                               "rules": Array [
                                                                 [Function],
                                                                 [Function],
@@ -3958,10 +4042,13 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                     </button>
                                   </StyledComponent>
                                 </SubMenu__ButtonSubMenu>
-                                <Reveal
+                                <FadeAndReveal
+                                  delay={0}
                                   duration={500}
                                   height={0}
                                   in={true}
+                                  onEntered={[Function]}
+                                  onExited={[Function]}
                                   timeout={500}
                                 >
                                   <Transition
@@ -3980,345 +4067,395 @@ exports[`SideNavigation renders without vertical spacing 1`] = `
                                     timeout={500}
                                     unmountOnExit={false}
                                   >
-                                    <div
+                                    <FadeAndReveal__StyledContainer
                                       aria-hidden={false}
-                                      data-testid="childrenContainer"
                                       style={
                                         Object {
-                                          "height": "0px",
+                                          "height": 0,
+                                          "opacity": 1,
                                           "overflow": "hidden",
-                                          "transition": "height 500ms",
+                                          "transition": "height 500ms, opacity 500ms ease-in-out",
                                         }
                                       }
                                     >
-                                      <SubMenu__SubMenuContainer>
-                                        <StyledComponent
-                                          forwardedComponent={
+                                      <StyledComponent
+                                        aria-hidden={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c13",
+                                              "rules": Array [
+                                                "@media (prefers-reduced-motion: reduce) {
+  transition: none !important;
+}",
+                                              ],
+                                            },
+                                            "displayName": "FadeAndReveal__StyledContainer",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "FadeAndReveal__StyledContainer-sc-1drkfnv-0",
+                                            "target": "div",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "opacity": 1,
+                                            "overflow": "hidden",
+                                            "transition": "height 500ms, opacity 500ms ease-in-out",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          aria-hidden={false}
+                                          className="c13"
+                                          style={
                                             Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                                                "isStatic": true,
-                                                "lastClassName": "c13",
-                                                "rules": Array [
-                                                  "margin-bottom: 1rem;",
-                                                ],
-                                              },
-                                              "displayName": "SubMenu__SubMenuContainer",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
-                                              "target": "ul",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
+                                              "height": 0,
+                                              "opacity": 1,
+                                              "overflow": "hidden",
+                                              "transition": "height 500ms, opacity 500ms ease-in-out",
                                             }
                                           }
-                                          forwardedRef={[Function]}
                                         >
-                                          <ul
-                                            className="c13"
-                                          >
-                                            <li
-                                              key=".0"
+                                          <SubMenu__SubMenuContainer>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c14",
+                                                    "rules": Array [
+                                                      "margin-bottom: 1rem;",
+                                                    ],
+                                                  },
+                                                  "displayName": "SubMenu__SubMenuContainer",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "SubMenu__SubMenuContainer-sc-1p1ex8g-0",
+                                                  "target": "ul",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={[Function]}
                                             >
-                                              <Link
-                                                active={true}
-                                                href="#"
-                                                reactRouterLinkComponent={null}
-                                                subMenuLink={true}
-                                                to={null}
+                                              <ul
+                                                className="c14"
                                               >
-                                                <Link__StyledAnchor
-                                                  href="#"
-                                                  to={null}
+                                                <li
+                                                  key=".0"
                                                 >
-                                                  <StyledComponent
-                                                    forwardedComponent={
-                                                      Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "attrs": Array [],
-                                                        "componentStyle": ComponentStyle {
-                                                          "componentId": "Link__StyledAnchor-gur8v7-4",
-                                                          "isStatic": true,
-                                                          "lastClassName": "c4",
-                                                          "rules": Array [
-                                                            "text-decoration: none;",
-                                                          ],
-                                                        },
-                                                        "displayName": "Link__StyledAnchor",
-                                                        "foldedComponentIds": Array [],
-                                                        "render": [Function],
-                                                        "styledComponentId": "Link__StyledAnchor-gur8v7-4",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
+                                                  <Link
+                                                    active={true}
                                                     href="#"
+                                                    reactRouterLinkComponent={null}
+                                                    subMenuLink={true}
                                                     to={null}
                                                   >
-                                                    <a
-                                                      className="c4"
+                                                    <Link__StyledAnchor
                                                       href="#"
                                                       to={null}
                                                     >
-                                                      <Link__BoxWrapper
-                                                        active={1}
-                                                      >
-                                                        <StyledComponent
-                                                          active={1}
-                                                          forwardedComponent={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "attrs": Array [],
-                                                              "componentStyle": ComponentStyle {
-                                                                "componentId": "Link__BoxWrapper-gur8v7-1",
-                                                                "isStatic": false,
-                                                                "lastClassName": "c14",
-                                                                "rules": Array [
-                                                                  [Function],
-                                                                ],
-                                                              },
-                                                              "displayName": "Link__BoxWrapper",
-                                                              "foldedComponentIds": Array [],
-                                                              "render": [Function],
-                                                              "styledComponentId": "Link__BoxWrapper-gur8v7-1",
-                                                              "target": [Function],
-                                                              "toString": [Function],
-                                                              "warnTooManyClasses": [Function],
-                                                              "withComponent": [Function],
-                                                            }
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "Link__StyledAnchor-gur8v7-4",
+                                                              "isStatic": true,
+                                                              "lastClassName": "c4",
+                                                              "rules": Array [
+                                                                "text-decoration: none;",
+                                                              ],
+                                                            },
+                                                            "displayName": "Link__StyledAnchor",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "Link__StyledAnchor-gur8v7-4",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
                                                           }
-                                                          forwardedRef={null}
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="#"
+                                                        to={null}
+                                                      >
+                                                        <a
+                                                          className="c4"
+                                                          href="#"
+                                                          to={null}
                                                         >
-                                                          <Box
+                                                          <Link__BoxWrapper
                                                             active={1}
-                                                            className="c14"
-                                                            inline={false}
-                                                            tag="div"
                                                           >
-                                                            <div
+                                                            <StyledComponent
                                                               active={1}
-                                                              className="c14"
+                                                              forwardedComponent={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "attrs": Array [],
+                                                                  "componentStyle": ComponentStyle {
+                                                                    "componentId": "Link__BoxWrapper-gur8v7-1",
+                                                                    "isStatic": false,
+                                                                    "lastClassName": "c15",
+                                                                    "rules": Array [
+                                                                      [Function],
+                                                                    ],
+                                                                  },
+                                                                  "displayName": "Link__BoxWrapper",
+                                                                  "foldedComponentIds": Array [],
+                                                                  "render": [Function],
+                                                                  "styledComponentId": "Link__BoxWrapper-gur8v7-1",
+                                                                  "target": [Function],
+                                                                  "toString": [Function],
+                                                                  "warnTooManyClasses": [Function],
+                                                                  "withComponent": [Function],
+                                                                }
+                                                              }
+                                                              forwardedRef={null}
                                                             >
-                                                              <Link__BoxContainer
+                                                              <Box
                                                                 active={1}
-                                                                submenulink={1}
-                                                                vertical={3}
+                                                                className="c15"
+                                                                inline={false}
+                                                                tag="div"
                                                               >
-                                                                <StyledComponent
+                                                                <div
                                                                   active={1}
-                                                                  forwardedComponent={
-                                                                    Object {
-                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                      "attrs": Array [],
-                                                                      "componentStyle": ComponentStyle {
-                                                                        "componentId": "Link__BoxContainer-gur8v7-0",
-                                                                        "isStatic": false,
-                                                                        "lastClassName": "c15",
-                                                                        "rules": Array [
-                                                                          [Function],
-                                                                        ],
-                                                                      },
-                                                                      "displayName": "Link__BoxContainer",
-                                                                      "foldedComponentIds": Array [],
-                                                                      "render": [Function],
-                                                                      "styledComponentId": "Link__BoxContainer-gur8v7-0",
-                                                                      "target": [Function],
-                                                                      "toString": [Function],
-                                                                      "warnTooManyClasses": [Function],
-                                                                      "withComponent": [Function],
-                                                                    }
-                                                                  }
-                                                                  forwardedRef={null}
-                                                                  submenulink={1}
-                                                                  vertical={3}
+                                                                  className="c15"
                                                                 >
-                                                                  <Box
+                                                                  <Link__BoxContainer
                                                                     active={1}
-                                                                    className="c15"
-                                                                    inline={false}
                                                                     submenulink={1}
-                                                                    tag="div"
                                                                     vertical={3}
                                                                   >
-                                                                    <div
+                                                                    <StyledComponent
                                                                       active={1}
-                                                                      className="TDS_Box-modules__verticalPadding-3___Fsv37 c15"
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "Link__BoxContainer-gur8v7-0",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "c16",
+                                                                            "rules": Array [
+                                                                              [Function],
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "Link__BoxContainer",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "Link__BoxContainer-gur8v7-0",
+                                                                          "target": [Function],
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
                                                                       submenulink={1}
+                                                                      vertical={3}
                                                                     >
-                                                                      <Link__BoxActive
+                                                                      <Box
                                                                         active={1}
-                                                                        horizontal={3}
+                                                                        className="c16"
+                                                                        inline={false}
                                                                         submenulink={1}
+                                                                        tag="div"
+                                                                        vertical={3}
                                                                       >
-                                                                        <StyledComponent
+                                                                        <div
                                                                           active={1}
-                                                                          forwardedComponent={
-                                                                            Object {
-                                                                              "$$typeof": Symbol(react.forward_ref),
-                                                                              "attrs": Array [],
-                                                                              "componentStyle": ComponentStyle {
-                                                                                "componentId": "Link__BoxActive-gur8v7-2",
-                                                                                "isStatic": false,
-                                                                                "lastClassName": "c16",
-                                                                                "rules": Array [
-                                                                                  [Function],
-                                                                                ],
-                                                                              },
-                                                                              "displayName": "Link__BoxActive",
-                                                                              "foldedComponentIds": Array [],
-                                                                              "render": [Function],
-                                                                              "styledComponentId": "Link__BoxActive-gur8v7-2",
-                                                                              "target": [Function],
-                                                                              "toString": [Function],
-                                                                              "warnTooManyClasses": [Function],
-                                                                              "withComponent": [Function],
-                                                                            }
-                                                                          }
-                                                                          forwardedRef={null}
-                                                                          horizontal={3}
+                                                                          className="TDS_Box-modules__verticalPadding-3___Fsv37 c16"
                                                                           submenulink={1}
                                                                         >
-                                                                          <Box
+                                                                          <Link__BoxActive
                                                                             active={1}
-                                                                            className="c16"
                                                                             horizontal={3}
-                                                                            inline={false}
                                                                             submenulink={1}
-                                                                            tag="div"
                                                                           >
-                                                                            <div
+                                                                            <StyledComponent
                                                                               active={1}
-                                                                              className="TDS_Box-modules__horizontalPadding-3___2uoUp c16"
+                                                                              forwardedComponent={
+                                                                                Object {
+                                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                                  "attrs": Array [],
+                                                                                  "componentStyle": ComponentStyle {
+                                                                                    "componentId": "Link__BoxActive-gur8v7-2",
+                                                                                    "isStatic": false,
+                                                                                    "lastClassName": "c17",
+                                                                                    "rules": Array [
+                                                                                      [Function],
+                                                                                    ],
+                                                                                  },
+                                                                                  "displayName": "Link__BoxActive",
+                                                                                  "foldedComponentIds": Array [],
+                                                                                  "render": [Function],
+                                                                                  "styledComponentId": "Link__BoxActive-gur8v7-2",
+                                                                                  "target": [Function],
+                                                                                  "toString": [Function],
+                                                                                  "warnTooManyClasses": [Function],
+                                                                                  "withComponent": [Function],
+                                                                                }
+                                                                              }
+                                                                              forwardedRef={null}
+                                                                              horizontal={3}
                                                                               submenulink={1}
                                                                             >
-                                                                              <Link__StyledTextProvider
-                                                                                active={true}
+                                                                              <Box
+                                                                                active={1}
+                                                                                className="c17"
+                                                                                horizontal={3}
+                                                                                inline={false}
+                                                                                submenulink={1}
+                                                                                tag="div"
                                                                               >
-                                                                                <StyledComponent
-                                                                                  active={true}
-                                                                                  forwardedComponent={
-                                                                                    Object {
-                                                                                      "$$typeof": Symbol(react.forward_ref),
-                                                                                      "attrs": Array [],
-                                                                                      "componentStyle": ComponentStyle {
-                                                                                        "componentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                        "isStatic": false,
-                                                                                        "lastClassName": "c17",
-                                                                                        "rules": Array [
-                                                                                          [Function],
-                                                                                        ],
-                                                                                      },
-                                                                                      "displayName": "Link__StyledTextProvider",
-                                                                                      "foldedComponentIds": Array [],
-                                                                                      "render": [Function],
-                                                                                      "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
-                                                                                      "target": [Function],
-                                                                                      "toString": [Function],
-                                                                                      "warnTooManyClasses": [Function],
-                                                                                      "withComponent": [Function],
-                                                                                    }
-                                                                                  }
-                                                                                  forwardedRef={null}
+                                                                                <div
+                                                                                  active={1}
+                                                                                  className="TDS_Box-modules__horizontalPadding-3___2uoUp c17"
+                                                                                  submenulink={1}
                                                                                 >
-                                                                                  <ColoredTextProvider
+                                                                                  <Link__StyledTextProvider
                                                                                     active={true}
-                                                                                    className="c17"
                                                                                   >
-                                                                                    <div
-                                                                                      className="c17"
+                                                                                    <StyledComponent
+                                                                                      active={true}
+                                                                                      forwardedComponent={
+                                                                                        Object {
+                                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                                          "attrs": Array [],
+                                                                                          "componentStyle": ComponentStyle {
+                                                                                            "componentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                            "isStatic": false,
+                                                                                            "lastClassName": "c18",
+                                                                                            "rules": Array [
+                                                                                              [Function],
+                                                                                            ],
+                                                                                          },
+                                                                                          "displayName": "Link__StyledTextProvider",
+                                                                                          "foldedComponentIds": Array [],
+                                                                                          "render": [Function],
+                                                                                          "styledComponentId": "Link__StyledTextProvider-gur8v7-3",
+                                                                                          "target": [Function],
+                                                                                          "toString": [Function],
+                                                                                          "warnTooManyClasses": [Function],
+                                                                                          "withComponent": [Function],
+                                                                                        }
+                                                                                      }
+                                                                                      forwardedRef={null}
                                                                                     >
-                                                                                      <Text
-                                                                                        block={false}
-                                                                                        bold={true}
-                                                                                        invert={false}
-                                                                                        size="small"
+                                                                                      <ColoredTextProvider
+                                                                                        active={true}
+                                                                                        className="c18"
                                                                                       >
-                                                                                        <Text__StyledText
-                                                                                          block={false}
-                                                                                          bold={true}
-                                                                                          inheritColor={true}
-                                                                                          invert={false}
-                                                                                          size="small"
+                                                                                        <div
+                                                                                          className="c18"
                                                                                         >
-                                                                                          <StyledComponent
+                                                                                          <Text
                                                                                             block={false}
                                                                                             bold={true}
-                                                                                            forwardedComponent={
-                                                                                              Object {
-                                                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                                                "attrs": Array [],
-                                                                                                "componentStyle": ComponentStyle {
-                                                                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                  "isStatic": false,
-                                                                                                  "lastClassName": "c18",
-                                                                                                  "rules": Array [
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    [Function],
-                                                                                                    "sup {
-  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
-}",
-                                                                                                  ],
-                                                                                                },
-                                                                                                "displayName": "Text__StyledText",
-                                                                                                "foldedComponentIds": Array [],
-                                                                                                "render": [Function],
-                                                                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                                                                                "target": "span",
-                                                                                                "toString": [Function],
-                                                                                                "warnTooManyClasses": [Function],
-                                                                                                "withComponent": [Function],
-                                                                                              }
-                                                                                            }
-                                                                                            forwardedRef={null}
-                                                                                            inheritColor={true}
                                                                                             invert={false}
                                                                                             size="small"
                                                                                           >
-                                                                                            <span
-                                                                                              className="c18"
+                                                                                            <Text__StyledText
+                                                                                              block={false}
+                                                                                              bold={true}
+                                                                                              inheritColor={true}
+                                                                                              invert={false}
                                                                                               size="small"
                                                                                             >
-                                                                                              Option 1
-                                                                                            </span>
-                                                                                          </StyledComponent>
-                                                                                        </Text__StyledText>
-                                                                                      </Text>
-                                                                                    </div>
-                                                                                  </ColoredTextProvider>
-                                                                                </StyledComponent>
-                                                                              </Link__StyledTextProvider>
-                                                                            </div>
-                                                                          </Box>
-                                                                        </StyledComponent>
-                                                                      </Link__BoxActive>
-                                                                    </div>
-                                                                  </Box>
-                                                                </StyledComponent>
-                                                              </Link__BoxContainer>
-                                                            </div>
-                                                          </Box>
-                                                        </StyledComponent>
-                                                      </Link__BoxWrapper>
-                                                    </a>
-                                                  </StyledComponent>
-                                                </Link__StyledAnchor>
-                                              </Link>
-                                            </li>
-                                          </ul>
-                                        </StyledComponent>
-                                      </SubMenu__SubMenuContainer>
-                                    </div>
+                                                                                              <StyledComponent
+                                                                                                block={false}
+                                                                                                bold={true}
+                                                                                                forwardedComponent={
+                                                                                                  Object {
+                                                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                                                    "attrs": Array [],
+                                                                                                    "componentStyle": ComponentStyle {
+                                                                                                      "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                      "isStatic": false,
+                                                                                                      "lastClassName": "c19",
+                                                                                                      "rules": Array [
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        [Function],
+                                                                                                        "sup {
+  top: -0.5em; font-size: 0.875rem; position: relative; vertical-align: baseline; padding-left: 0.1em;
+}",
+                                                                                                      ],
+                                                                                                    },
+                                                                                                    "displayName": "Text__StyledText",
+                                                                                                    "foldedComponentIds": Array [],
+                                                                                                    "render": [Function],
+                                                                                                    "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                                                                    "target": "span",
+                                                                                                    "toString": [Function],
+                                                                                                    "warnTooManyClasses": [Function],
+                                                                                                    "withComponent": [Function],
+                                                                                                  }
+                                                                                                }
+                                                                                                forwardedRef={null}
+                                                                                                inheritColor={true}
+                                                                                                invert={false}
+                                                                                                size="small"
+                                                                                              >
+                                                                                                <span
+                                                                                                  className="c19"
+                                                                                                  size="small"
+                                                                                                >
+                                                                                                  Option 1
+                                                                                                </span>
+                                                                                              </StyledComponent>
+                                                                                            </Text__StyledText>
+                                                                                          </Text>
+                                                                                        </div>
+                                                                                      </ColoredTextProvider>
+                                                                                    </StyledComponent>
+                                                                                  </Link__StyledTextProvider>
+                                                                                </div>
+                                                                              </Box>
+                                                                            </StyledComponent>
+                                                                          </Link__BoxActive>
+                                                                        </div>
+                                                                      </Box>
+                                                                    </StyledComponent>
+                                                                  </Link__BoxContainer>
+                                                                </div>
+                                                              </Box>
+                                                            </StyledComponent>
+                                                          </Link__BoxWrapper>
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </Link__StyledAnchor>
+                                                  </Link>
+                                                </li>
+                                              </ul>
+                                            </StyledComponent>
+                                          </SubMenu__SubMenuContainer>
+                                        </div>
+                                      </StyledComponent>
+                                    </FadeAndReveal__StyledContainer>
                                   </Transition>
-                                </Reveal>
+                                </FadeAndReveal>
                               </SubMenu>
                             </li>
                           </StyledComponent>

--- a/packages/SideNavigation/package.json
+++ b/packages/SideNavigation/package.json
@@ -30,7 +30,7 @@
     "@tds/core-colours": "^1.1.2",
     "@tds/core-decorative-icon": "^1.2.0",
     "@tds/core-text": "^2.0.0",
-    "@tds/shared-animation": "1.1.0",
+    "@tds/shared-animation": "^2.0.1",
     "@tds/shared-typography": "^1.3.3",
     "@tds/util-helpers": "^1.2.0",
     "@tds/util-prop-types": "^1.3.2",


### PR DESCRIPTION
## Related issues

https://github.com/telus/tds-community/issues/297

## Description

Fix 1: Fixes issue where opening a submenu can expand to outside of side navigation container
Feature 1: Collapsing the submenu will now fade out the text within the submenu

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
