### PR TITLE
fix(community-toggle-switch): makes spinnerLabel prop optional

### DIFF
--- a/packages/ToggleSwitch/ToggleSwitch.jsx
+++ b/packages/ToggleSwitch/ToggleSwitch.jsx
@@ -22,7 +22,9 @@ const ToggleSwitch = React.forwardRef(
     if (tooltipText && !tooltipCopy) {
       warn('@tds/community-toggle-switch', 'You must provide tooltipCopy when using tooltipText')
     }
-
+    if (isLoading && !spinnerLabel) {
+      warn('@tds/community-toggle-switch', 'You must provide spinnerLabel when using isLoading')
+    }
     const labelledById = `${id}-label`
     const buttonRef = useRef()
 

--- a/packages/ToggleSwitch/ToggleSwitch.jsx
+++ b/packages/ToggleSwitch/ToggleSwitch.jsx
@@ -113,7 +113,7 @@ ToggleSwitch.propTypes = {
   tooltipCopy: PropTypes.string,
 
   /** Communicates a message to assistive technology while spinner is visible. */
-  spinnerLabel: PropTypes.string.isRequired,
+  spinnerLabel: PropTypes.string,
 
   /** A callback function to be invoked when the ToggleSwitch button is clicked on.
    @param {SyntheticEvent} event The React `SyntheticEvent` */
@@ -127,6 +127,7 @@ ToggleSwitch.defaultProps = {
   checked: false,
   tooltipText: undefined,
   tooltipCopy: undefined,
+  spinnerLabel: undefined,
   isLoading: false,
 }
 

--- a/packages/ToggleSwitch/__tests__/ToggleSwitch.spec.jsx
+++ b/packages/ToggleSwitch/__tests__/ToggleSwitch.spec.jsx
@@ -11,7 +11,6 @@ describe('ToggleSwitch', () => {
     name: 'name',
     value: 'value',
     toolTipCopy: 'en',
-    spinnerLabel: 'Request is processing.',
     onClick: mockOnClick,
   }
 
@@ -150,7 +149,10 @@ describe('ToggleSwitch', () => {
   })
 
   it('show spinner when isLoading=true', () => {
-    const toggleSwitch = doShallow({ isLoading: true })
+    const toggleSwitch = doShallow({
+      isLoading: true,
+      spinnerLabel: 'Request is processing.',
+    })
     const spinner = toggleSwitch.find('Spinner')
     expect(spinner.prop('spinning')).toEqual(true)
   })

--- a/packages/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.spec.jsx.snap
+++ b/packages/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.spec.jsx.snap
@@ -75,7 +75,6 @@ exports[`ToggleSwitch renders 1`] = `
   label="label"
   name="name"
   onClick={[MockFunction]}
-  spinnerLabel="Request is processing."
   toolTipCopy="en"
   value="value"
 >
@@ -170,7 +169,6 @@ exports[`ToggleSwitch renders 1`] = `
                 dangerouslyHideVisibleLabel={false}
                 fullScreen={false}
                 inline={true}
-                label="Request is processing."
                 size="small"
                 spinning={false}
                 tag="span"


### PR DESCRIPTION
`ToggleSwitch` required `spinnerLabel`, yet `isLoading` prop is optional. `spinnerLabel` is only needed in cases where `isLoading` prop is passed.

## Related issues

Fixes issue #311

## Description

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
