### PR TITLE
QuietButton Component

### DIFF
--- a/docs/setup/tds-core-globals.js
+++ b/docs/setup/tds-core-globals.js
@@ -14,8 +14,11 @@ import Text from '@tds/core-text'
 import UnorderedList from '@tds/core-unordered-list'
 import Image from '@tds/core-image'
 import Spinner from '@tds/core-spinner'
+import { Edit, Print } from '@tds/core-interactive-icon'
+import A11yContent from '@tds/core-a11y-content'
 
 Object.assign(global, {
+  A11yContent,
   Box,
   Card,
   ChevronLink,
@@ -32,4 +35,6 @@ Object.assign(global, {
   Image,
   Button,
   Spinner,
+  Edit,
+  Print,
 })

--- a/packages/DatePicker/package.json
+++ b/packages/DatePicker/package.json
@@ -30,7 +30,7 @@
     "@tds/core-colours": "^2.2.1",
     "@tds/core-decorative-icon": "^2.6.4",
     "@tds/core-responsive": "^1.3.3",
-    "@tds/shared-typography": "^1.3.3",
+    "@tds/shared-typography": "^1.3.5",
     "@tds/util-helpers": "^1.2.0",
     "prop-types": "^15.6.2",
     "react-dates": "^21.4.0",

--- a/packages/SideNavigation/package.json
+++ b/packages/SideNavigation/package.json
@@ -31,7 +31,7 @@
     "@tds/core-decorative-icon": "^2.6.4",
     "@tds/core-text": "^3.0.4",
     "@tds/shared-animation": "^2.0.1",
-    "@tds/shared-typography": "^1.3.3",
+    "@tds/shared-typography": "^1.3.5",
     "@tds/util-helpers": "^1.2.0",
     "@tds/util-prop-types": "^1.3.2",
     "prop-types": "^15.6.2"

--- a/packages/_private/QuietButton/QuietButton.jsx
+++ b/packages/_private/QuietButton/QuietButton.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types'
 
 const baseButton = {
   boxSizing: 'border-box',
-  margin: '2px 0',
+  margin: '2px',
   padding: '0px 16px 0px 16px',
   cursor: 'pointer',
   background: '#FFFFFF',
@@ -23,13 +23,13 @@ const baseButton = {
     midWidth: '72px',
   },
   '&:active': {
-    border: '3px solid #54595F',
+    border: '1px solid #54595F',
+    boxShadow: '0 0 0 2px #54595F',
     background: '#D8D8D8',
   },
   '&:focus': {
     background: '#FFFFFF',
-    border: '2px solid white',
-    boxShadow: '0 0 0 3px #71757B, 0 0 0 1px #54595F inset',
+    boxShadow: '0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset, 0 0 0 3px #54595F inset',
     outline: 'none !important',
   },
   '@media (prefers-reduced-motion: reduce)': {
@@ -51,7 +51,7 @@ const spaceWrapper = {
 
 const StyledQuietButton = styled.button(baseButton, small, borders.rounded)
 const ButtonWrapper = styled.div(btnWrapper)
-export const SpaceWrapper = styled.div(spaceWrapper)
+const SpaceWrapper = styled.div(spaceWrapper)
 
 const spaceFunction = childrenArray => {
   return childrenArray.map((child, index) => {
@@ -61,17 +61,16 @@ const spaceFunction = childrenArray => {
     return <SpaceWrapper key={child || child.type.name}>{child}</SpaceWrapper>
   })
 }
-
 /**
  * The quiet button is used for optional actions, and only comes in one variant and size
  * @version ./package.json
  */
+
 const QuietButton = ({ children, ...rest }) => {
-  if (!children) throw new Error('QuietButton component requires children')
   const childrenArray = Array.isArray(children) ? children : [children]
 
   return (
-    <StyledQuietButton {...safeRest(rest)}>
+    <StyledQuietButton type="button" {...safeRest(rest)}>
       <ButtonWrapper>{spaceFunction(childrenArray)}</ButtonWrapper>
     </StyledQuietButton>
   )
@@ -81,6 +80,7 @@ QuietButton.propTypes = {
   /**
    * Button children.
    */
+
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
 }
 

--- a/packages/_private/QuietButton/QuietButton.jsx
+++ b/packages/_private/QuietButton/QuietButton.jsx
@@ -53,11 +53,6 @@ const StyledQuietButton = styled.button(baseButton, small, borders.rounded)
 const ButtonWrapper = styled.div(btnWrapper)
 export const SpaceWrapper = styled.div(spaceWrapper)
 
-/**
- * The quiet button is used for optional actions, and only comes in one variant and size
- * @version ./package.json
- */
-
 const spaceFunction = childrenArray => {
   return childrenArray.map((child, index) => {
     if (child.type && child.type.name !== 'A11yContent' && index === childrenArray.length - 1) {
@@ -67,6 +62,10 @@ const spaceFunction = childrenArray => {
   })
 }
 
+/**
+ * The quiet button is used for optional actions, and only comes in one variant and size
+ * @version ./package.json
+ */
 const QuietButton = ({ children, ...rest }) => {
   if (!children) throw new Error('QuietButton component requires children')
   const childrenArray = Array.isArray(children) ? children : [children]

--- a/packages/_private/QuietButton/QuietButton.jsx
+++ b/packages/_private/QuietButton/QuietButton.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import styled from 'styled-components'
+import { safeRest } from '@tds/util-helpers'
+import { small } from '@tds/shared-typography'
+import { borders } from '@tds/shared-styles'
+import PropTypes from 'prop-types'
+
+const baseButton = {
+  boxSizing: 'border-box',
+  margin: '2px 0',
+  padding: '0px 16px 0px 16px',
+  cursor: 'pointer',
+  background: '#FFFFFF',
+  transition: 'all 0.2s ease-in-out',
+  minWidth: '44px',
+  height: '28px',
+  border: '1px solid #71757B',
+  position: 'relative',
+  borderRadius: '3px',
+  color: '#2A2C2E',
+  '&:hover': {
+    boxShadow: '0 0 0 2px #71757B',
+    midWidth: '72px',
+  },
+  '&:active': {
+    border: '3px solid #54595F',
+    background: '#D8D8D8',
+  },
+  '&:focus': {
+    background: '#FFFFFF',
+    border: '2px solid white',
+    boxShadow: '0 0 0 3px #71757B, 0 0 0 1px #54595F inset',
+    outline: 'none !important',
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    transition: 'none !important',
+  },
+}
+const btnWrapper = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  padding: '3px 0px 5px 0px',
+  '& svg': {
+    margin: '-3px 0 -5px 0',
+  },
+}
+const spaceWrapper = {
+  paddingRight: '4px',
+}
+
+const StyledQuietButton = styled.button(baseButton, small, borders.rounded)
+const ButtonWrapper = styled.div(btnWrapper)
+export const SpaceWrapper = styled.div(spaceWrapper)
+
+/**
+ * The quiet button is used for optional actions, and only comes in one variant and size
+ * @version ./package.json
+ */
+
+const spaceFunction = childrenArray => {
+  return childrenArray.map((child, index) => {
+    if (child.type && child.type.name !== 'A11yContent' && index === childrenArray.length - 1) {
+      return child
+    }
+    return <SpaceWrapper key={child || child.type.name}>{child}</SpaceWrapper>
+  })
+}
+
+const QuietButton = ({ children, ...rest }) => {
+  if (!children) throw new Error('QuietButton component requires children')
+  const childrenArray = Array.isArray(children) ? children : [children]
+
+  return (
+    <StyledQuietButton {...safeRest(rest)}>
+      <ButtonWrapper>{spaceFunction(childrenArray)}</ButtonWrapper>
+    </StyledQuietButton>
+  )
+}
+
+QuietButton.propTypes = {
+  /**
+   * Button children.
+   */
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+}
+
+export default QuietButton

--- a/packages/_private/QuietButton/QuietButton.md
+++ b/packages/_private/QuietButton/QuietButton.md
@@ -1,0 +1,51 @@
+Quiet buttons are used sparingly and for an optional action. Mainly used in internal applications like My TELUS (web and app) or Casa; it only comes in one variant and size.
+
+### Usage criteria
+
+- Use for interactions that are not necessarily mandatory
+- Use for enhanced experience where if the button does not exist, the customer can still do what they need to
+- Keep the text short and precise, recommendation is text that describes an action (Ie. Copy, Edit, Print)
+- Make use of the A11yContent core component to provide more written context for assistive technology users for when they navigate a page using only button landmarks
+- Buttons should not be disabled
+
+```jsx
+<QuietButton>Text</QuietButton>
+```
+
+#### QuietButton with Icons
+
+- Only dependent icons can be added into buttons, they can be on the left or right of the label
+- The colour of the text and icon have to be the same
+
+```jsx
+<QuietButton>
+  <Edit />
+  Left Icon
+</QuietButton>
+```
+
+```jsx
+<QuietButton>
+  Right Icon
+  <Print />
+</QuietButton>
+```
+
+#### Using A11yContent
+
+Use the `A11yContent` component to create invisible text that is read out loud by screen readers.
+
+```jsx
+<QuietButton>
+  <A11yContent>testing</A11yContent>
+  With A11y Content
+</QuietButton>
+```
+
+#### Adding Functionality
+
+Provide a function as the onClick prop to perform an action when clicked.
+
+```jsx
+<QuietButton onClick={() => alert('You clicked the button!')}>Click me!</QuietButton>
+```

--- a/packages/_private/QuietButton/README.md
+++ b/packages/_private/QuietButton/README.md
@@ -1,0 +1,1 @@
+# TDS Community: QuietButton

--- a/packages/_private/QuietButton/__tests__/QuietButton.spec.jsx
+++ b/packages/_private/QuietButton/__tests__/QuietButton.spec.jsx
@@ -55,10 +55,6 @@ describe('QuietButton', () => {
     expect(button.text()).toEqual('Text')
   })
 
-  it('should throw an error if no children are passed', () => {
-    expect(() => shallow(<QuietButton />)).toThrow()
-  })
-
   it('should do something when clicked', () => {
     const mockCallBack = jest.fn()
     const button = shallow(<QuietButton onClick={mockCallBack}>Text</QuietButton>)

--- a/packages/_private/QuietButton/__tests__/QuietButton.spec.jsx
+++ b/packages/_private/QuietButton/__tests__/QuietButton.spec.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import 'jest-styled-components'
+
+import A11yContent from '@tds/core-a11y-content'
+import { Edit } from '@tds/core-interactive-icon'
+import QuietButton from '../QuietButton'
+
+describe('QuietButton', () => {
+  const doShallow = (props = {}) => shallow(<QuietButton {...props}>Words</QuietButton>)
+  const doMount = (props = {}) => mount(<QuietButton {...props}>Words</QuietButton>)
+
+  it('renders', () => {
+    const quietButton = doMount()
+
+    expect(quietButton).toMatchSnapshot()
+    quietButton.unmount()
+  })
+
+  it('does not allow custom CSS', () => {
+    const quietButton = doShallow({
+      className: 'my-custom-class',
+      style: { color: 'hotpink' },
+    })
+
+    expect(quietButton).not.toHaveProp('className', 'my-custom-class')
+    expect(quietButton).not.toHaveProp('style')
+  })
+
+  it('should contain A11yContent', () => {
+    const button = shallow(
+      <QuietButton>
+        Go home
+        <A11yContent>testing</A11yContent>
+      </QuietButton>
+    )
+
+    expect(button).toContainReact(<A11yContent>testing</A11yContent>)
+  })
+
+  it('should contain an interactiveIcon', () => {
+    const button = shallow(
+      <QuietButton>
+        Go home
+        <Edit />
+      </QuietButton>
+    )
+
+    expect(button).toContainReact(<Edit />)
+  })
+
+  it('should contain text', () => {
+    const button = shallow(<QuietButton>Text</QuietButton>)
+
+    expect(button.text()).toEqual('Text')
+  })
+
+  it('should throw an error if no children are passed', () => {
+    expect(() => shallow(<QuietButton />)).toThrow()
+  })
+
+  it('should do something when clicked', () => {
+    const mockCallBack = jest.fn()
+    const button = shallow(<QuietButton onClick={mockCallBack}>Text</QuietButton>)
+    button.simulate('click')
+    expect(mockCallBack.mock.calls.length).toEqual(1)
+  })
+})

--- a/packages/_private/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
+++ b/packages/_private/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
@@ -1,0 +1,215 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuietButton renders 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 2px 0;
+  padding: 0px 16px 0px 16px;
+  cursor: pointer;
+  background: #FFFFFF;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  min-width: 44px;
+  height: 28px;
+  border: 1px solid #71757B;
+  position: relative;
+  border-radius: 3px;
+  color: #2A2C2E;
+  word-wrap: break-word;
+  font-size: 0.875rem;
+  -webkit-letter-spacing: -0.6px;
+  -moz-letter-spacing: -0.6px;
+  -ms-letter-spacing: -0.6px;
+  letter-spacing: -0.6px;
+  line-height: 1.42857;
+  border-radius: 4px;
+}
+
+.c0:hover {
+  box-shadow: 0 0 0 2px #71757B;
+  mid-width: 72px;
+}
+
+.c0:active {
+  border: 3px solid #54595F;
+  background: #D8D8D8;
+}
+
+.c0:focus {
+  background: #FFFFFF;
+  border: 2px solid white;
+  box-shadow: 0 0 0 3px #71757B,0 0 0 1px #54595F inset;
+  outline: none !important;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 3px 0px 5px 0px;
+}
+
+.c1 svg {
+  margin: -3px 0 -5px 0;
+}
+
+.c2 {
+  padding-right: 4px;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c0 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
+}
+
+<QuietButton>
+  <QuietButton__StyledQuietButton>
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "QuietButton__StyledQuietButton-sc-1anctzy-0",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "box-sizing: border-box;",
+              "margin: 2px 0;",
+              "padding: 0px 16px 0px 16px;",
+              "cursor: pointer;",
+              "background: #FFFFFF;",
+              "transition: all 0.2s ease-in-out;",
+              "min-width: 44px;",
+              "height: 28px;",
+              "border: 1px solid #71757B;",
+              "position: relative;",
+              "border-radius: 3px;",
+              "color: #2A2C2E;",
+              "&:hover {",
+              "box-shadow: 0 0 0 2px #71757B;",
+              "mid-width: 72px;",
+              "}",
+              "&:active {",
+              "border: 3px solid #54595F;",
+              "background: #D8D8D8;",
+              "}",
+              "&:focus {",
+              "background: #FFFFFF;",
+              "border: 2px solid white;",
+              "box-shadow: 0 0 0 3px #71757B, 0 0 0 1px #54595F inset;",
+              "outline: none !important;",
+              "}",
+              "@media (prefers-reduced-motion: reduce) {",
+              "transition: none !important;",
+              "}",
+              "word-wrap: break-word;",
+              "font-size: 0.875rem;",
+              "letter-spacing: -0.6px;",
+              "line-height: 1.42857;",
+              "border-radius: 4px;",
+            ],
+          },
+          "displayName": "QuietButton__StyledQuietButton",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "QuietButton__StyledQuietButton-sc-1anctzy-0",
+          "target": "button",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <button
+        className="c0"
+      >
+        <QuietButton__ButtonWrapper>
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
+                  "isStatic": false,
+                  "lastClassName": "c1",
+                  "rules": Array [
+                    "display: flex;",
+                    "flex-direction: row;",
+                    "align-items: center;",
+                    "padding: 3px 0px 5px 0px;",
+                    "& svg {",
+                    "margin: -3px 0 -5px 0;",
+                    "}",
+                  ],
+                },
+                "displayName": "QuietButton__ButtonWrapper",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+          >
+            <div
+              className="c1"
+            >
+              <QuietButton__SpaceWrapper
+                key="Words"
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "QuietButton__SpaceWrapper-sc-1anctzy-2",
+                        "isStatic": false,
+                        "lastClassName": "c2",
+                        "rules": Array [
+                          "padding-right: 4px;",
+                        ],
+                      },
+                      "displayName": "QuietButton__SpaceWrapper",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "QuietButton__SpaceWrapper-sc-1anctzy-2",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                >
+                  <div
+                    className="c2"
+                  >
+                    Words
+                  </div>
+                </StyledComponent>
+              </QuietButton__SpaceWrapper>
+            </div>
+          </StyledComponent>
+        </QuietButton__ButtonWrapper>
+      </button>
+    </StyledComponent>
+  </QuietButton__StyledQuietButton>
+</QuietButton>
+`;

--- a/packages/_private/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
+++ b/packages/_private/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`QuietButton renders 1`] = `
 .c0 {
   box-sizing: border-box;
-  margin: 2px 0;
+  margin: 2px;
   padding: 0px 16px 0px 16px;
   cursor: pointer;
   background: #FFFFFF;
@@ -31,14 +31,14 @@ exports[`QuietButton renders 1`] = `
 }
 
 .c0:active {
-  border: 3px solid #54595F;
+  border: 1px solid #54595F;
+  box-shadow: 0 0 0 2px #54595F;
   background: #D8D8D8;
 }
 
 .c0:focus {
   background: #FFFFFF;
-  border: 2px solid white;
-  box-shadow: 0 0 0 3px #71757B,0 0 0 1px #54595F inset;
+  box-shadow: 0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset,0 0 0 3px #54595F inset;
   outline: none !important;
 }
 
@@ -73,7 +73,9 @@ exports[`QuietButton renders 1`] = `
 }
 
 <QuietButton>
-  <QuietButton__StyledQuietButton>
+  <QuietButton__StyledQuietButton
+    type="button"
+  >
     <StyledComponent
       forwardedComponent={
         Object {
@@ -85,7 +87,7 @@ exports[`QuietButton renders 1`] = `
             "lastClassName": "c0",
             "rules": Array [
               "box-sizing: border-box;",
-              "margin: 2px 0;",
+              "margin: 2px;",
               "padding: 0px 16px 0px 16px;",
               "cursor: pointer;",
               "background: #FFFFFF;",
@@ -101,13 +103,13 @@ exports[`QuietButton renders 1`] = `
               "mid-width: 72px;",
               "}",
               "&:active {",
-              "border: 3px solid #54595F;",
+              "border: 1px solid #54595F;",
+              "box-shadow: 0 0 0 2px #54595F;",
               "background: #D8D8D8;",
               "}",
               "&:focus {",
               "background: #FFFFFF;",
-              "border: 2px solid white;",
-              "box-shadow: 0 0 0 3px #71757B, 0 0 0 1px #54595F inset;",
+              "box-shadow: 0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset, 0 0 0 3px #54595F inset;",
               "outline: none !important;",
               "}",
               "@media (prefers-reduced-motion: reduce) {",
@@ -131,9 +133,11 @@ exports[`QuietButton renders 1`] = `
         }
       }
       forwardedRef={null}
+      type="button"
     >
       <button
         className="c0"
+        type="button"
       >
         <QuietButton__ButtonWrapper>
           <StyledComponent

--- a/packages/_private/QuietButton/index.cjs.js
+++ b/packages/_private/QuietButton/index.cjs.js
@@ -1,0 +1,3 @@
+const QuietButton = require('./dist/index.cjs')
+
+module.exports = QuietButton

--- a/packages/_private/QuietButton/index.es.js
+++ b/packages/_private/QuietButton/index.es.js
@@ -1,0 +1,3 @@
+import QuietButton from './dist/index.es'
+
+export default QuietButton

--- a/packages/_private/QuietButton/package.json
+++ b/packages/_private/QuietButton/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@tds/community-quiet-button",
+  "version": "0.1.0-0",
+  "description": "",
+  "main": "index.cjs.js",
+  "module": "index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/telus/tds-community.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "TELUS digital",
+  "engines": {
+    "node": ">=8"
+  },
+  "bugs": {
+    "url": "https://github.com/telus/tds-community/issues"
+  },
+  "homepage": "http://tds.telus.com",
+  "peerDependencies": {
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2",
+    "styled-components": "^4.1.3"
+  },
+  "dependencies": {
+    "@tds/util-helpers": "^1.2.0",
+    "prop-types": "^15.6.2"
+  }
+}

--- a/packages/_private/QuietButton/package.json
+++ b/packages/_private/QuietButton/package.json
@@ -26,6 +26,8 @@
     "styled-components": "^4.1.3"
   },
   "dependencies": {
+    "@tds/shared-styles": "^1.5.2",
+    "@tds/shared-typography": "^1.3.5",
     "@tds/util-helpers": "^1.2.0",
     "prop-types": "^15.6.2"
   }

--- a/packages/_private/QuietButton/rollup.config.js
+++ b/packages/_private/QuietButton/rollup.config.js
@@ -1,0 +1,7 @@
+import configure from '../../../config/rollup.config'
+import { dependencies } from './package.json'
+
+export default configure({
+  input: './QuietButton.jsx',
+  dependencies,
+})


### PR DESCRIPTION
#New Quiet Button Component
See #361 

## Jira Ticket
This pull request addresses [Jira Ticket DJR-2475](https://telusdigital.atlassian.net/browse/DJR-2475).

## Description
Quiet buttons are used sparingly and for an optional action. Mainly used in internal applications like My TELUS (web and app) or Casa; it only comes in one variant and size.

### Acceptance Criteria
- _~~No~~_  **"Safe Rest"** properties are accepted (to allow `onClick` handler etc.)
- Child elements are accepted:
    - [<InteractiveIcon>](https://tds.telus.com/components/index.html#/Icons?id=section-interactive-icons) is an appropriate child element, and can appear on the left or right of the text
    - String text alone is an appropriate child element
    - [<A11yContent>](https://tds.telus.com/components/index.html#/Content?id=a11ycontent) is an appropriate child element

Elements in StyleGuidist:
<img width="978" alt="Screen Shot 2020-06-09 at 1 58 15 PM" src="https://user-images.githubusercontent.com/9220735/84183130-67e39200-aa59-11ea-9dd1-d6927f15976f.png">

Quiet buttons in Active, Focus, and Hover states, per [Invision Design](https://telus.invisionapp.com/d/main#/console/13491097/419340834/preview):
<img width="610" alt="Screen Shot 2020-06-09 at 2 01 45 PM" src="https://user-images.githubusercontent.com/9220735/84183389-d6c0eb00-aa59-11ea-95de-2b6a5c6976f4.png">

## Checklist before submitting pull request

- [x] Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
