### PR TITLE
feat(community-waffle-grid): add new waffle grid component

### DIFF
--- a/packages/WaffleGrid/README.md
+++ b/packages/WaffleGrid/README.md
@@ -1,0 +1,1 @@
+# TDS Community: WaffleGrid

--- a/packages/WaffleGrid/WaffleGrid.jsx
+++ b/packages/WaffleGrid/WaffleGrid.jsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import Box from '@tds/core-box'
+import Link from '@tds/core-link'
+import Image from '@tds/core-image'
+import Paragraph from '@tds/core-paragraph'
+import { media } from '@tds/core-responsive'
+import { colorGreyGainsboro } from '@tds/core-colours'
+
+import { safeRest } from '@tds/util-helpers'
+
+const StyledLogoRow = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-start',
+  ...media.from('lg').css({
+    'div:not(:last-child)': {
+      borderRight: `1px solid ${colorGreyGainsboro}`,
+    },
+    'div:nth-of-type(6n)': {
+      borderRight: '0px',
+    },
+  }),
+  ...media
+    .from('sm')
+    .until('lg')
+    .css({
+      '> div:nth-of-type(1):nth-of-last-child(3)': {
+        borderBottom: '5px solid black',
+      },
+      'div:nth-of-type(3n - 1)': {
+        borderLeft: `1px solid ${colorGreyGainsboro}`,
+        borderRight: `1px solid ${colorGreyGainsboro}`,
+      },
+      'div:nth-of-type(3n - 1):last-child': {
+        borderLeft: `1px solid ${colorGreyGainsboro}`,
+      },
+      '> div:not(:last-child)': {
+        borderBottom: `1px solid ${colorGreyGainsboro}`,
+      },
+      'div:nth-last-of-type(-n+3):nth-of-type(3n) ~ *': {
+        borderBottom: `1px solid ${colorGreyGainsboro}`,
+        '&:last-child': {
+          borderRight: '0px',
+        },
+      },
+      'div:nth-last-of-type(-n+4):nth-of-type(3n) ~ *': {
+        borderBottom: '0px',
+      },
+    }),
+  ...media.until('sm').css({
+    'div:nth-of-type(even)': {
+      borderLeft: `1px solid ${colorGreyGainsboro}`,
+    },
+    '> div:not(:last-child)': {
+      borderBottom: `1px solid ${colorGreyGainsboro}`,
+    },
+    '> div:nth-last-of-type(-n+2):not(:nth-of-type(even))': {
+      borderBottom: '0px',
+    },
+  }),
+})
+
+const StyledLogoWrapper = styled('div')({
+  flexDirection: 'column',
+  ...media.until('sm').css({
+    flex: '0 1 50%',
+    width: '50%',
+    alignItems: 'center',
+    paddingBottom: '16px',
+    '~ div:nth-of-type(n + 3)': {
+      paddingTop: '16px',
+    },
+    '~ div:nth-last-of-type(-n + 2)': {
+      paddingBottom: '0px',
+    },
+  }),
+  ...media
+    .from('sm')
+    .until('lg')
+    .css({
+      flex: '0 1 33%',
+      width: '33%',
+      paddingBottom: '16px',
+      '~ :nth-of-type(n + 4)': {
+        paddingTop: '16px',
+        paddingBottom: '0px',
+      },
+    }),
+  ...media.from('lg').css({
+    flex: '0 1 16%',
+    width: '16%',
+  }),
+})
+
+const StyledCentre = styled('div')({
+  flexDirection: 'column',
+  alignItems: 'center',
+  textAlign: 'center',
+})
+
+/**
+ * The WaffleGrid is used to show items in a waffle like manner with borders surrounding the element
+ * @version ./package.json
+ * @visibleName WaffleGrid (beta)
+ */
+const WaffleGrid = ({ items, ...rest }) => (
+  <Box between={5} {...safeRest(rest)}>
+    <StyledCentre>
+      <StyledLogoRow inline between={0}>
+        {items.map(child => (
+          <StyledLogoWrapper key={child}>
+            <StyledCentre>
+              <Link href={child.href}>
+                <Image src={child.image} alt={child.imageAltText} width={56} height={56} />
+                <Paragraph align="center">{child.text}</Paragraph>
+              </Link>
+            </StyledCentre>
+          </StyledLogoWrapper>
+        ))}
+      </StyledLogoRow>
+    </StyledCentre>
+  </Box>
+)
+
+WaffleGrid.propTypes = {
+  /**
+   * The image and the link to display. `items` should be an array of objects with the following keys:
+   */
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * The src attribute for the HTML img element
+       */
+      image: PropTypes.string,
+      /**
+       * The alt attribute for the HTML img element
+       */
+      imageAltText: PropTypes.string,
+      /**
+       * The text displayed under the image
+       */
+      text: PropTypes.string,
+      /**
+       * Target URL
+       */
+      href: PropTypes.string,
+    })
+  ).isRequired,
+}
+
+export default WaffleGrid

--- a/packages/WaffleGrid/WaffleGrid.md
+++ b/packages/WaffleGrid/WaffleGrid.md
@@ -1,0 +1,63 @@
+### Usage criteria
+
+- Use when you want an image and a text displayed under the image, as a link, to have a separating border either on the right or left and/or under the image/text
+- Desktop/large view will have all the items in a single row
+- Tablet/medium view will have the `3` items in a row
+- Mobile/small view will have `2` items in a row
+
+### Future iterations
+
+- Handle `paddingBottom` on six or more items for `tablet` view
+- Handle `borderBottom` and `paddingBottom`/`paddingTop` on 6 or more items in `desktop` view
+- Handle the extra `borderBottom` and `borderRight` in `tablet` view when there are only two or three items
+- Consider what should happen given a very long text to display
+- Consider accepting "node" properties to be flexible to display more than just a link
+
+```jsx
+<WaffleGrid
+  items={[
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+    {
+      image:
+        'https://images.ctfassets.net/3cqlnin176yn/6fbpuI7xGEQwM0sueuEMmy/8768c289e22006227aa1ebf64bd05cf4/stevie.jpg',
+      imageAltText: 'The image alt text',
+      href: '//telus.com',
+      text: 'TELUS',
+    },
+  ]}
+/>
+```

--- a/packages/WaffleGrid/__tests__/WaffleGrid.spec.jsx
+++ b/packages/WaffleGrid/__tests__/WaffleGrid.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import WaffleGrid from '../WaffleGrid'
+
+describe('WaffleGrid', () => {
+  const defaultProps = {
+    items: [
+      {
+        image: 'www.image.com/cool.svg',
+        imageAltText: 'Cool image',
+        href: 'www.image.com',
+        text: 'Cool image',
+      },
+    ],
+  }
+  const doShallow = (props = {}) => shallow(<WaffleGrid {...defaultProps} {...props} />)
+
+  it('renders', () => {
+    const waffleGrid = doShallow()
+
+    expect(waffleGrid).toMatchSnapshot()
+  })
+
+  it('passes additional attributes to the element', () => {
+    const waffleGrid = doShallow({ id: 'the-id', 'data-some-attr': 'some value' })
+
+    expect(waffleGrid).toHaveProp('id', 'the-id')
+    expect(waffleGrid).toHaveProp('data-some-attr', 'some value')
+  })
+
+  it('does not allow custom CSS', () => {
+    const waffleGrid = doShallow({
+      className: 'my-custom-class',
+      style: { color: 'hotpink' },
+    })
+
+    expect(waffleGrid).not.toHaveProp('className', 'my-custom-class')
+    expect(waffleGrid).not.toHaveProp('style')
+  })
+})

--- a/packages/WaffleGrid/__tests__/__snapshots__/WaffleGrid.spec.jsx.snap
+++ b/packages/WaffleGrid/__tests__/__snapshots__/WaffleGrid.spec.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WaffleGrid renders 1`] = `
+<Box
+  between={5}
+  inline={false}
+  tag="div"
+>
+  <WaffleGrid__StyledCentre>
+    <WaffleGrid__StyledLogoRow
+      between={0}
+      inline={true}
+    >
+      <WaffleGrid__StyledLogoWrapper
+        key="[object Object]"
+      >
+        <WaffleGrid__StyledCentre>
+          <WithForwardedRef(Link)
+            href="www.image.com"
+          >
+            <Image
+              alt="Cool image"
+              height={56}
+              src="www.image.com/cool.svg"
+              width={56}
+            />
+            <Paragraph
+              align="center"
+              bold={false}
+              invert={false}
+              size="medium"
+            >
+              Cool image
+            </Paragraph>
+          </WithForwardedRef(Link)>
+        </WaffleGrid__StyledCentre>
+      </WaffleGrid__StyledLogoWrapper>
+    </WaffleGrid__StyledLogoRow>
+  </WaffleGrid__StyledCentre>
+</Box>
+`;

--- a/packages/WaffleGrid/index.cjs.js
+++ b/packages/WaffleGrid/index.cjs.js
@@ -1,0 +1,3 @@
+const WaffleGrid = require('./dist/index.cjs')
+
+module.exports = WaffleGrid

--- a/packages/WaffleGrid/index.es.js
+++ b/packages/WaffleGrid/index.es.js
@@ -1,0 +1,3 @@
+import WaffleGrid from './dist/index.es'
+
+export default WaffleGrid

--- a/packages/WaffleGrid/package.json
+++ b/packages/WaffleGrid/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tds/community-waffle-grid",
+  "version": "0.1.0-0",
+  "description": "",
+  "main": "index.cjs.js",
+  "module": "index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/telus/tds-community.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "TELUS digital",
+  "engines": {
+    "node": ">=8"
+  },
+  "bugs": {
+    "url": "https://github.com/telus/tds-community/issues"
+  },
+  "homepage": "http://tds.telus.com",
+  "peerDependencies": {
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2",
+    "styled-components": "^4.1.3"
+  },
+  "dependencies": {
+    "@tds/core-box": "^2.1.3",
+    "@tds/core-colours": "^2.2.1",
+    "@tds/core-image": "^2.0.20",
+    "@tds/core-link": "^2.2.5",
+    "@tds/core-paragraph": "^2.0.12",
+    "@tds/core-responsive": "^1.3.3",
+    "@tds/util-helpers": "^1.2.0",
+    "prop-types": "^15.6.2"
+  }
+}

--- a/packages/WaffleGrid/rollup.config.js
+++ b/packages/WaffleGrid/rollup.config.js
@@ -1,0 +1,7 @@
+import configure from '../../config/rollup.config'
+import { dependencies } from './package.json'
+
+export default configure({
+  input: './WaffleGrid.jsx',
+  dependencies,
+})


### PR DESCRIPTION
## Description
This is creating a new "Waffle" type like component where it adds `<HairlineDivider>` to separate the items in the component

`Desktop`
![Screen Shot 2020-06-26 at 7 13 07 PM](https://user-images.githubusercontent.com/30445300/85908015-6fd55d00-b7e1-11ea-9456-889b52beb3d0.png)

`Tablet`
![Screen Shot 2020-06-26 at 7 13 17 PM](https://user-images.githubusercontent.com/30445300/85908014-6fd55d00-b7e1-11ea-96e5-23f5ca7515c8.png)

`Mobile`
![Screen Shot 2020-06-26 at 7 13 28 PM](https://user-images.githubusercontent.com/30445300/85908013-6ea43000-b7e1-11ea-9e93-fa7bcd0e02c5.png)

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
