### PR TITLE
feat(packages): add Below component to add space below

### DIFF
--- a/packages/Below/Below.jsx
+++ b/packages/Below/Below.jsx
@@ -1,0 +1,79 @@
+import React, { forwardRef } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { responsiveProps } from '@tds/util-prop-types'
+
+import handleResponsiveStyles from './handleResponsiveStyles'
+
+/**
+ * The Below component is used to add spacing below a component where that spacing is not equal to the top spacing
+ * The default spacing if no props are passed is box-spacing 8 (64px in mobile, 96px in desktop)
+ * @version ./package.json
+ * @visibleName Below (beta)
+ */
+const spacing = {
+  mobile: {
+    0: '0rem',
+    1: '0.25rem',
+    2: '0.5rem',
+    3: '1rem',
+    4: '1.5rem',
+    5: '2rem',
+    6: '2.5rem',
+    7: '3rem',
+    8: '4rem',
+  },
+  desktop: {
+    0: '0rem',
+    1: '0.25rem',
+    2: '0.5rem',
+    3: '1rem',
+    4: '2rem',
+    5: '3rem',
+    6: '4rem',
+    7: '4.5rem',
+    8: '6rem',
+  },
+}
+
+export const convertToRem = (level, breakpoint) => {
+  if (['xs', 'sm'].indexOf(breakpoint) !== -1) {
+    return spacing.mobile[level]
+  }
+  return spacing.desktop[level]
+}
+
+const belowStyles = props =>
+  handleResponsiveStyles({ space: props.space }, ({ space }, breakpoint) => {
+    if (space === undefined) {
+      return undefined
+    }
+
+    const rem = convertToRem(space, breakpoint)
+
+    return {
+      marginBottom: rem,
+    }
+  })
+
+const BelowComponent = styled.div(belowStyles)
+
+const Below = forwardRef((props, ref) => <BelowComponent {...props} ref={ref} />)
+
+Below.displayName = 'Below'
+
+Below.propTypes = {
+  /**
+   * Indent the spacing that is added by the Below component.
+   *
+   * One of: `0,1,2,3,4,5,6,7,8` as a [**responsive prop**](#responsiveProps). Default is
+   * 8, as this element is designed for page bottom spacing.
+   */
+  space: responsiveProps(PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8])),
+}
+
+Below.defaultProps = {
+  space: 8,
+}
+
+export default Below

--- a/packages/Below/Below.md
+++ b/packages/Below/Below.md
@@ -1,0 +1,19 @@
+The Below component is designed to add additional space at the bottom of a page. The current TDS Box system is based on the idea of equal space at the top and bottom of components, so Below can be used where additional space is required at the bottom of a page to meet design best practices.
+
+### Usage criteria
+
+By default, if no arguments are passed to the below component, it defaults to providing a TDS level 8 (4 rem in mobile and 6 rem in desktop).
+
+```jsx
+<p>This is the last component in a page. It needs some extra space beneath it.</p>
+<Below />
+```
+
+For more customizable amounts of space below components, the TDS level of space (1 - 8) can be provided as the space property. If space levels outside of 1-8 are provided, no space is provided. Properties must match the TDS box space levels. For additional flexibility, responsive properties can be provided, to provide different amounts of space on mobile and desktop views
+
+```jsx
+<p>This is theoretically the last component in a page. It needs space beneath it, but not too much.</p>
+<Below space={5} />
+<p>This is ACTUALLY the last component in a page, to give an example of responsive below props.</p>
+<Below space={{xs: 6, md: 7}} />
+```

--- a/packages/Below/README.md
+++ b/packages/Below/README.md
@@ -1,0 +1,1 @@
+# TDS Community: Below

--- a/packages/Below/__tests__/Below.spec.jsx
+++ b/packages/Below/__tests__/Below.spec.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Below, { convertToRem } from '../Below'
+import handleResponsiveStyle from '../handleResponsiveStyles'
+
+describe('convertToRem', () => {
+  it('works for phone screens', () => {
+    const rem = convertToRem(8, 'xs')
+    expect(rem).toEqual('4rem')
+  })
+  it('works for big screens', () => {
+    const rem = convertToRem(7, 'md')
+    expect(rem).toEqual('4.5rem')
+  })
+})
+
+describe('handleResponsiveStyle', () => {
+  const props = {
+    space: { xs: 8 },
+  }
+  const styleFn = ({ space }, breakpoint) => {
+    if (space === undefined) {
+      return undefined
+    }
+
+    const rem = convertToRem(space, breakpoint)
+
+    return { marginBottom: rem }
+  }
+
+  it('returns styles based on media size', () => {
+    const styles = handleResponsiveStyle(props, styleFn)
+    expect(styles).toEqual({
+      '@media (max-width: 767px)': {
+        marginBottom: '4rem',
+      },
+      '@media (min-width: 768px)': {
+        marginBottom: '6rem',
+      },
+    })
+  })
+})
+
+describe('Below', () => {
+  const doShallow = (props = {}) => shallow(<Below {...props} />)
+
+  it('renders', () => {
+    const props = {
+      space: 4,
+    }
+    const below = doShallow(props)
+
+    expect(below).toMatchSnapshot()
+  })
+
+  it('defaults to size 8', () => {
+    const below = doShallow()
+    expect(below).toHaveProp('space', 8)
+  })
+
+  it('handles responsive props', () => {
+    const below = doShallow({ space: { xs: 3, md: 4 } })
+    expect(below).toHaveProp('space', { xs: 3, md: 4 })
+    expect(below).toMatchSnapshot()
+  })
+})

--- a/packages/Below/__tests__/__snapshots__/Below.spec.jsx.snap
+++ b/packages/Below/__tests__/__snapshots__/Below.spec.jsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Below handles responsive props 1`] = `
+<Below__BelowComponent
+  space={
+    Object {
+      "md": 4,
+      "xs": 3,
+    }
+  }
+/>
+`;
+
+exports[`Below renders 1`] = `
+<Below__BelowComponent
+  space={4}
+/>
+`;

--- a/packages/Below/handleResponsiveStyles.js
+++ b/packages/Below/handleResponsiveStyles.js
@@ -1,0 +1,37 @@
+import { prepareArray, generateStyles } from '@tds/util-helpers'
+
+const MOBILE_BREAKPOINTS = ['xs', 'sm']
+const DESKTOP_BREAKPOINTS = ['md', 'lg', 'xl']
+
+export const isMobileBreakpoint = breakpoint => MOBILE_BREAKPOINTS.indexOf(breakpoint) !== -1
+export const isDesktopBreakpoint = breakpoint => DESKTOP_BREAKPOINTS.indexOf(breakpoint) !== -1
+
+const handleBoundaryCrossing = (acc, curr) => {
+  if (
+    isMobileBreakpoint(curr.from) &&
+    ((curr.until !== 'md' && isDesktopBreakpoint(curr.until)) || typeof curr.until === 'undefined')
+  ) {
+    const props = Object.keys(curr.props).filter(
+      prop => typeof curr.props[prop] === 'number' && curr.props[prop] > 3
+    )
+    if (props.length !== 0) {
+      const mobileBreakpoint = { ...curr, props: curr.props }
+      const desktopBreakpoint = { ...curr, props: curr.props }
+
+      mobileBreakpoint.until = 'md'
+      desktopBreakpoint.from = 'md'
+
+      return acc.concat([mobileBreakpoint, desktopBreakpoint])
+    }
+  }
+  return acc.concat([curr])
+}
+
+const handleResponsiveStyles = (props, styleFn) => {
+  const breakpoints = prepareArray(props)
+    .filter(bp => Object.keys(bp.props).length > 0)
+    .reduce(handleBoundaryCrossing, [])
+  return generateStyles(breakpoints, styleFn)
+}
+
+export default handleResponsiveStyles

--- a/packages/Below/index.cjs.js
+++ b/packages/Below/index.cjs.js
@@ -1,0 +1,3 @@
+const Below = require('./dist/index.cjs')
+
+module.exports = Below

--- a/packages/Below/index.es.js
+++ b/packages/Below/index.es.js
@@ -1,0 +1,3 @@
+import Below from './dist/index.es'
+
+export default Below

--- a/packages/Below/package.json
+++ b/packages/Below/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@tds/community-below",
+  "version": "0.1.0-0",
+  "description": "",
+  "main": "index.cjs.js",
+  "module": "index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/telus/tds-community.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "TELUS digital",
+  "engines": {
+    "node": ">=8"
+  },
+  "bugs": {
+    "url": "https://github.com/telus/tds-community/issues"
+  },
+  "homepage": "http://tds.telus.com",
+  "peerDependencies": {
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2",
+    "styled-components": "^4.1.3"
+  },
+  "dependencies": {
+    "@tds/util-helpers": "^1.2.0",
+    "@tds/util-prop-types": "^1.3.2",
+    "prop-types": "^15.6.2"
+  }
+}

--- a/packages/Below/rollup.config.js
+++ b/packages/Below/rollup.config.js
@@ -1,0 +1,7 @@
+import configure from '../../config/rollup.config'
+import { dependencies } from './package.json'
+
+export default configure({
+  input: './Below.jsx',
+  dependencies,
+})


### PR DESCRIPTION
The Below component is designed to add additional space at the bottom of a page. The current TDS Box system is based on the idea of equal space at the top and bottom of components, so Below can be used where additional space is required at the bottom of a page to meet design best practices.

By default, if no arguments are passed to the below component, it defaults to providing a TDS level 8 (4 rem in mobile and 6 rem in desktop). For more customizable amounts of space below components, the TDS level of space (1 - 8) can be provided as the space property. If space levels outside of 1-8 are provided, no space is provided. Properties must match the TDS box space levels. For additional flexibility, responsive properties can be provided, to provide different amounts of space on mobile and desktop views.

<img width="1048" alt="Screen Shot 2020-08-10 at 4 35 49 PM" src="https://user-images.githubusercontent.com/9220735/89828816-98ae7900-db27-11ea-89bd-edf1951579e8.png">
