### PR TITLE
feat(community-modal): make confirmCTAText and onConfirm props optional

### DIFF
--- a/packages/Modal/Modal.jsx
+++ b/packages/Modal/Modal.jsx
@@ -118,16 +118,18 @@ const Modal = ({
                     </div>
                     {description}
                   </Box>
-                  <PaddingOverride>
-                    <Box vertical={5}>
-                      <CTAWrapper cancelCTAExists={cancelCTAText}>
-                        <Button onClick={onConfirm}>{confirmCTAText}</Button>
-                        {cancelCTAText && (
-                          <OutlineButton onClick={handleClose}>{cancelCTAText}</OutlineButton>
-                        )}
-                      </CTAWrapper>
-                    </Box>
-                  </PaddingOverride>
+                  {confirmCTAText && (
+                    <PaddingOverride>
+                      <Box vertical={5}>
+                        <CTAWrapper cancelCTAExists={cancelCTAText}>
+                          <Button onClick={onConfirm}>{confirmCTAText}</Button>
+                          {cancelCTAText && (
+                            <OutlineButton onClick={handleClose}>{cancelCTAText}</OutlineButton>
+                          )}
+                        </CTAWrapper>
+                      </Box>
+                    </PaddingOverride>
+                  )}
                 </Box>
               </ModalWrapper>
               <CloseButtonWrapper>
@@ -155,7 +157,7 @@ Modal.propTypes = {
    *
    * Text that represents confirm CTA.
    */
-  confirmCTAText: PropTypes.string.isRequired,
+  confirmCTAText: PropTypes.string,
   /**
    *
    * Text that represents cancel CTA or closing modal action.
@@ -178,7 +180,7 @@ Modal.propTypes = {
    *
    * Handler Function used to proceed with modal CTA.
    */
-  onConfirm: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func,
   /**
    *
    * Accepts a React Element's Ref, in order to focus on it after modal closes. Modal will call your ref as `ref.current.focus()`
@@ -191,7 +193,9 @@ Modal.propTypes = {
 }
 
 Modal.defaultProps = {
+  confirmCTAText: '',
   cancelCTAText: '',
+  onConfirm: null,
 }
 
 export default Modal

--- a/packages/Modal/__tests__/Modal.spec.jsx
+++ b/packages/Modal/__tests__/Modal.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import Heading from '@tds/core-heading'
 import Box from '@tds/core-box'
-import { mount } from 'enzyme'
+import Button from '@tds/core-button'
+import { mount, shallow } from 'enzyme'
 
 import Modal from '../Modal'
 
@@ -70,6 +71,26 @@ describe('Modal', () => {
 
     expect(modalWithCustomContent.contains(heading)).toEqual(true)
     expect(modalWithCustomContent.contains(bodyText)).toEqual(true)
+  })
+
+  it('should not show cta when confirmCTAText is empty', () => {
+    const doShallow = (props = {}) =>
+      shallow(
+        <Modal
+          isOpen={true}
+          heading="A heading"
+          bodyText="Text"
+          confirmCTAText=""
+          focusElementAfterClose={{}}
+          onConfirm={() => {}}
+          onClose={() => {}}
+          {...props}
+        />
+      )
+
+    const modalWithNoCta = doShallow()
+
+    expect(modalWithNoCta.find(Button)).toHaveLength(0)
   })
 
   //   Check if confirm and cancel buttons appear when using Dialogue Modal


### PR DESCRIPTION
## Description

<!-- 'Description' section is optional -->

- Feat: `confirmCTAText` and `onConfirm` props are optional and backwards compatible

When there is no text provided to `confirmCTAText` , the confirm CTA should not appear

## Screenshots
<img width="1106" alt="Screen Shot 2020-09-11 at 12 38 27 PM" src="https://user-images.githubusercontent.com/3418750/92953294-79a94c80-f42f-11ea-9bb0-6935ef98cf18.png">


## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
