### PR TITLE
feat: RadioCard community component

### DIFF
--- a/packages/RadioCard/README.md
+++ b/packages/RadioCard/README.md
@@ -1,0 +1,1 @@
+# TDS Community: RadioCard

--- a/packages/RadioCard/RadioCard.jsx
+++ b/packages/RadioCard/RadioCard.jsx
@@ -85,37 +85,31 @@ const HiddenInput = styled.input(getStates, {
   },
 })
 
-const StyledLabel = styled.label(
-  getVariant,
-  borders.none,
-  borders.rounded,
-  ({ width, height }) => ({
-    display: 'flex',
-    cursor: 'pointer',
-    height: `${height}px`,
-    width: `${width}px`,
-    border: `0.0625rem solid ${colorGreyGainsboro}`,
-    boxShadow: '0 0 1rem 0 rgba(0, 0, 0, 0.1)',
-    backgroundColor: colorWhite,
-    transition: 'transform 0.2s ease-in-out, background 0.2s, color 0.2s, border 0.2s ease',
-    '&:hover': {
-      transform: 'scale(1.025)',
+const StyledLabel = styled.label(getVariant, borders.none, borders.rounded, {
+  display: 'flex',
+  cursor: 'pointer',
+  height: '100%',
+  border: `0.0625rem solid ${colorGreyGainsboro}`,
+  boxShadow: '0 0 1rem 0 rgba(0, 0, 0, 0.1)',
+  backgroundColor: colorWhite,
+  transition: 'transform 0.2s ease-in-out, background 0.2s, color 0.2s, border 0.2s ease',
+  '&:hover': {
+    transform: 'scale(1.025)',
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    transition: 'none !important',
+  },
+  [`${HiddenInput}:focus ~ & > div > div > ${FakeRadio}`]: {
+    boxShadow: `0 0 4px 1px ${colorGreyShuttle}`,
+    borderColor: colorWhite,
+  },
+  [`${HiddenInput}:checked ~ & > div > div > ${FakeRadio}`]: {
+    '& > span': {
+      display: 'block',
     },
-    '@media (prefers-reduced-motion: reduce)': {
-      transition: 'none !important',
-    },
-    [`${HiddenInput}:focus ~ & > div > div > ${FakeRadio}`]: {
-      boxShadow: `0 0 4px 1px ${colorGreyShuttle}`,
-      borderColor: colorWhite,
-    },
-    [`${HiddenInput}:checked ~ & > div > div > ${FakeRadio}`]: {
-      '& > span': {
-        display: 'block',
-      },
-      borderColor: colorGreyShuttle,
-    },
-  })
-)
+    borderColor: colorGreyShuttle,
+  },
+})
 
 const InnerChecked = styled.span({
   width: '0.75rem',
@@ -138,14 +132,20 @@ const getGeneratedId = (name, value) => {
 
 const StyledLabelBox = styled(Box)(labelBox)
 const StyledChildrenBox = styled(Box)({ marginLeft: '2.25rem' })
+const StyledDiv = styled.div(({ fullHeight }) => {
+  if (fullHeight) {
+    return { height: '100%' }
+  }
+  return {}
+})
 
 /**
  * @version ./package.json
  * @visibleName RadioCard (beta)
  */
 const RadioCard = React.forwardRef(
-  ({ id, name, value, label, width, height, variant, children, ...rest }, ref) => (
-    <div>
+  ({ id, name, value, label, fullHeight, variant, children, ...rest }, ref) => (
+    <StyledDiv fullHeight={fullHeight}>
       <HiddenInput
         type="radio"
         id={id || getGeneratedId(name, value)}
@@ -159,8 +159,6 @@ const RadioCard = React.forwardRef(
 
       <StyledLabel
         htmlFor={id || getGeneratedId(name, value)}
-        width={width}
-        height={height}
         variant={variant}
         data-testid="checkbox-label"
       >
@@ -174,7 +172,7 @@ const RadioCard = React.forwardRef(
           {children && <StyledChildrenBox>{children}</StyledChildrenBox>}
         </StyledLabelBox>
       </StyledLabel>
-    </div>
+    </StyledDiv>
   )
 )
 
@@ -204,13 +202,9 @@ RadioCard.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * Width of the radio card (in pixels).
+   * Sets the `Card`'s `height` equal to its parent.
    */
-  width: PropTypes.number.isRequired,
-  /**
-   * Height of the radio card (in pixels).
-   */
-  height: PropTypes.number.isRequired,
+  fullHeight: PropTypes.bool,
   /**
    * Additional details regarding the selection to present on the radio card.
    */
@@ -222,6 +216,7 @@ RadioCard.defaultProps = {
   variant: 'standard',
   id: undefined,
   children: null,
+  fullHeight: false,
 }
 
 RadioCard.displayName = 'RadioCard'

--- a/packages/RadioCard/RadioCard.jsx
+++ b/packages/RadioCard/RadioCard.jsx
@@ -1,0 +1,229 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import Heading from '@tds/core-heading'
+import Box from '@tds/core-box'
+import {
+  colorWhiteLilac,
+  colorPanache,
+  colorTelusPurple,
+  colorGreyGainsboro,
+  colorWhite,
+  colorGreyShuttle,
+  colorAccessibleGreen,
+} from '@tds/core-colours'
+
+import { borders } from '@tds/shared-styles'
+import { safeRest } from '@tds/util-helpers'
+import generateId from '../../shared/utils/generateId/generateId'
+
+const getVariant = ({ variant }) => {
+  const colour = variant === 'standard' ? colorAccessibleGreen : colorTelusPurple
+  const backgroundColour = variant === 'standard' ? colorPanache : colorWhiteLilac
+  return {
+    '&:hover': {
+      border: `0.0625rem solid ${colour} !important`,
+      boxShadow: `0 0 0 0.0625rem ${colour}  !important`,
+    },
+    '&:active': {
+      border: `0.0625rem solid ${colour}`,
+      boxShadow: `0 0 0 0.0625rem ${colour},0 0 0 0.125rem #FFFFFF inset, 0 0 0 0.1875rem ${colour} inset !important`,
+      background: backgroundColour,
+    },
+  }
+}
+
+const getStates = ({ variant }) => {
+  const colour = variant === 'standard' ? colorAccessibleGreen : colorTelusPurple
+  return {
+    '&:focus ~ label': {
+      boxShadow: `0 0 0 0.0625rem ${colour},0 0 0 0.125rem #FFFFFF inset, 0 0 0 0.1875rem ${colour} inset !important`,
+      border: `0.0625rem solid ${colour} !important`,
+    },
+    '&:checked ~ label': {
+      border: `0.0625rem solid ${colour}`,
+      boxShadow: `0 0 0 0.0625rem ${colour}`,
+    },
+  }
+}
+
+const FakeRadio = styled.span({
+  height: '1.25rem',
+  width: '1.25rem',
+  minHeight: '1.25rem',
+  minWidth: '1.25rem',
+
+  outline: 0,
+  lineHeight: 0,
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+
+  marginTop: '0.3rem',
+
+  transition: 'border-color 0.1s linear, background-color 0.1s linear',
+  borderRadius: '50%',
+  ...borders.thin,
+
+  borderColor: colorGreyShuttle,
+  backgroundColor: colorWhite,
+  '& > i': {
+    display: 'none',
+  },
+})
+const HiddenInput = styled.input(getStates, {
+  position: 'absolute',
+  width: '1.2rem',
+  height: '1.2rem',
+  margin: '2px 1px',
+  opacity: '0',
+  pointerEvents: 'none',
+  '&:focus ~ label': {
+    outline: 'none !important',
+  },
+})
+
+const StyledLabel = styled.label(
+  getVariant,
+  borders.none,
+  borders.rounded,
+  ({ width, height }) => ({
+    display: 'flex',
+    cursor: 'pointer',
+    height: `${height}px`,
+    width: `${width}px`,
+    border: `0.0625rem solid ${colorGreyGainsboro}`,
+    boxShadow: '0 0 1rem 0 rgba(0, 0, 0, 0.1)',
+    backgroundColor: colorWhite,
+    transition: 'transform 0.2s ease-in-out, background 0.2s, color 0.2s, border 0.2s ease',
+    '&:hover': {
+      transform: 'scale(1.025)',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'none !important',
+    },
+    [`${HiddenInput}:focus ~ & > div > div > ${FakeRadio}`]: {
+      boxShadow: `0 0 4px 1px ${colorGreyShuttle}`,
+      borderColor: colorWhite,
+    },
+    [`${HiddenInput}:checked ~ & > div > div > ${FakeRadio}`]: {
+      '& > span': {
+        display: 'block',
+      },
+      borderColor: colorGreyShuttle,
+    },
+  })
+)
+
+const InnerChecked = styled.span({
+  width: '0.75rem',
+  height: '0.75rem',
+  borderRadius: '50%',
+  backgroundColor: colorAccessibleGreen,
+  display: 'none',
+})
+
+const labelBox = {
+  width: '100%',
+  marginRight: '0.5rem',
+  '@media (min-width: 768px)': {
+    marginRight: '1rem',
+  },
+}
+const getGeneratedId = (name, value) => {
+  return generateId(name).postfix(value)
+}
+
+const StyledLabelBox = styled(Box)(labelBox)
+const StyledChildrenBox = styled(Box)({ marginLeft: '2.25rem' })
+
+/**
+ * @version ./package.json
+ * @visibleName RadioCard (beta)
+ */
+const RadioCard = React.forwardRef(
+  ({ id, name, value, label, width, height, variant, children, ...rest }, ref) => (
+    <div>
+      <HiddenInput
+        type="radio"
+        id={id || getGeneratedId(name, value)}
+        name={name}
+        value={value}
+        data-testid="hidden-input"
+        variant={variant}
+        ref={ref}
+        {...safeRest(rest)}
+      />
+
+      <StyledLabel
+        htmlFor={id || getGeneratedId(name, value)}
+        width={width}
+        height={height}
+        variant={variant}
+        data-testid="checkbox-label"
+      >
+        <StyledLabelBox vertical={4} horizontal={3}>
+          <Box between={3} inline>
+            <FakeRadio data-testid="fake-input">
+              <InnerChecked />
+            </FakeRadio>
+            <Heading level="h3">{label}</Heading>
+          </Box>
+          {children && <StyledChildrenBox>{children}</StyledChildrenBox>}
+        </StyledLabelBox>
+      </StyledLabel>
+    </div>
+  )
+)
+
+RadioCard.propTypes = {
+  /**
+   * The style.
+   */
+  variant: PropTypes.oneOf(['standard', 'brand']),
+  /**
+   * The label.
+   */
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  /**
+   * Associate this radio with a group. Set as the HTML name attribute.
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * The value. Must be unique within the group.
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+  /**
+   * Use `checked` for controlled radio.
+   */
+  checked: PropTypes.bool,
+  /**
+   * The id. Must be unique within the group. If no id is provided, one will be generated in the following format: `name_value`
+   */
+  id: PropTypes.string,
+  /**
+   * Width of the radio card (in pixels).
+   */
+  width: PropTypes.number.isRequired,
+  /**
+   * Height of the card (in pixels).
+   */
+  height: PropTypes.number.isRequired,
+  /**
+   * Additional details regarding the selection to present on the card.
+   */
+  children: PropTypes.node,
+}
+
+RadioCard.defaultProps = {
+  checked: undefined,
+  variant: 'standard',
+  id: undefined,
+  children: null,
+}
+
+RadioCard.displayName = 'RadioCard'
+
+export default RadioCard

--- a/packages/RadioCard/RadioCard.jsx
+++ b/packages/RadioCard/RadioCard.jsx
@@ -188,7 +188,7 @@ RadioCard.propTypes = {
    */
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   /**
-   * Associate this radio with a group. Set as the HTML name attribute.
+   * Associate this radio card with a group. Set as the HTML name attribute.
    */
   name: PropTypes.string.isRequired,
   /**
@@ -208,11 +208,11 @@ RadioCard.propTypes = {
    */
   width: PropTypes.number.isRequired,
   /**
-   * Height of the card (in pixels).
+   * Height of the radio card (in pixels).
    */
   height: PropTypes.number.isRequired,
   /**
-   * Additional details regarding the selection to present on the card.
+   * Additional details regarding the selection to present on the radio card.
    */
   children: PropTypes.node,
 }

--- a/packages/RadioCard/RadioCard.jsx
+++ b/packages/RadioCard/RadioCard.jsx
@@ -203,7 +203,7 @@ RadioCard.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * Sets the `Card`'s `height` equal to its parent.
+   * Sets the radio card `height` equal to its parent.
    */
   fullHeight: PropTypes.bool,
   /**

--- a/packages/RadioCard/RadioCard.jsx
+++ b/packages/RadioCard/RadioCard.jsx
@@ -98,6 +98,7 @@ const StyledLabel = styled.label(getVariant, borders.none, borders.rounded, {
   },
   '@media (prefers-reduced-motion: reduce)': {
     transition: 'none !important',
+    transform: 'none !important',
   },
   [`${HiddenInput}:focus ~ & > div > div > ${FakeRadio}`]: {
     boxShadow: `0 0 4px 1px ${colorGreyShuttle}`,

--- a/packages/RadioCard/RadioCard.md
+++ b/packages/RadioCard/RadioCard.md
@@ -1,0 +1,82 @@
+Similar to `Radio` buttons, `RadioCards` are used when there is a list of two or more options that are mutually exclusive and the user must select exactly one choice. `RadioCards` allow users to easily compare and see options with greater detail. Clicking anywhere on the card selects that option.
+
+### Usage criteria
+
+- All `RadioCards` within a group should have the same `height` and `width`
+- The state of the RadioCards should be controlled, and as such both a `checked` and an `onChange` prop should be passed to each RadioCard
+
+```jsx
+initialState = {
+  choice: '1payment',
+}
+
+const setChoice = event => {
+  setState({ choice: event.target.value })
+}
+
+;<Box between={2} inline>
+  <RadioCard
+    label="1 installment payment"
+    name="papn"
+    value="1payment"
+    width={315}
+    height={200}
+    checked={state.choice === '1payment'}
+    onChange={setChoice}
+  >
+    <Box vertical={3}>
+      <Paragraph>
+        <Text bold={true}>$206.50</Text> due August 15, 2020
+      </Paragraph>
+    </Box>
+  </RadioCard>
+
+  <RadioCard
+    label="2 installment payments"
+    name="papn"
+    value="2payment"
+    width={315}
+    height={200}
+    checked={state.choice === '2payment'}
+    onChange={setChoice}
+  >
+    <Box vertical={3}>
+      <Paragraph>
+        <Text bold={true}>$103.25</Text> due August 15, 2020
+      </Paragraph>
+      <Paragraph>
+        <Text bold={true}>$103.25</Text> due September 15, 2020
+      </Paragraph>
+    </Box>
+  </RadioCard>
+</Box>
+```
+
+### Variants
+
+By default, RadioCards will be displayed in the `standard` variant.
+
+```jsx
+<RadioCard
+  label="1 line selection"
+  name="selection"
+  value="selection"
+  width={240}
+  height={90}
+  checked={true}
+/>
+```
+
+The `brand` variant.
+
+```jsx
+<RadioCard
+  label="2 line selection"
+  name="selection2"
+  value="selection2"
+  variant="brand"
+  width={240}
+  height={90}
+  checked={true}
+/>
+```

--- a/packages/RadioCard/RadioCard.md
+++ b/packages/RadioCard/RadioCard.md
@@ -2,7 +2,8 @@ Similar to `Radio` buttons, `RadioCards` are used when there is a list of two or
 
 ### Usage criteria
 
-- All `RadioCards` within a group should have the same `height` and `width`
+- All `RadioCards` within a group should have the same height and width
+- Use the `fullHeight` prop to have the bottom edge of the `RadioCards` aligned. This is usually needed when using cards in a `FlexGrid` and will result in the `RadioCards` matching the height of their parent
 - The state of the RadioCards should be controlled, and as such both a `checked` and an `onChange` prop should be passed to each RadioCard
 
 ```jsx
@@ -14,42 +15,64 @@ const setChoice = event => {
   setState({ choice: event.target.value })
 }
 
-;<Box between={2} inline>
-  <RadioCard
-    label="1 installment payment"
-    name="papn"
-    value="1payment"
-    width={315}
-    height={200}
-    checked={state.choice === '1payment'}
-    onChange={setChoice}
-  >
-    <Box vertical={3}>
-      <Paragraph>
-        <Text bold={true}>$206.50</Text> due August 15, 2020
-      </Paragraph>
-    </Box>
-  </RadioCard>
-
-  <RadioCard
-    label="2 installment payments"
-    name="papn"
-    value="2payment"
-    width={315}
-    height={200}
-    checked={state.choice === '2payment'}
-    onChange={setChoice}
-  >
-    <Box vertical={3}>
-      <Paragraph>
-        <Text bold={true}>$103.25</Text> due August 15, 2020
-      </Paragraph>
-      <Paragraph>
-        <Text bold={true}>$103.25</Text> due September 15, 2020
-      </Paragraph>
-    </Box>
-  </RadioCard>
-</Box>
+;<FlexGrid>
+  <FlexGrid.Row>
+    <FlexGrid.Col xs={12} md={4}>
+      <RadioCard
+        label="1 installment payment"
+        name="papn"
+        value="1payment"
+        fullHeight={true}
+        checked={state.choice === '1payment'}
+        onChange={setChoice}
+      >
+        <Box below={3} />
+        <Paragraph>
+          <Text bold={true}>$206.50</Text> due August 15, 2020
+        </Paragraph>
+      </RadioCard>
+    </FlexGrid.Col>
+    <FlexGrid.Col xs={12} md={4}>
+      <RadioCard
+        label="2 installment payments"
+        name="papn"
+        value="2payment"
+        fullHeight={true}
+        checked={state.choice === '2payment'}
+        onChange={setChoice}
+      >
+        <Box below={3} />
+        <Paragraph>
+          <Text bold={true}>$103.25</Text> due August 15, 2020
+        </Paragraph>
+        <Paragraph>
+          <Text bold={true}>$103.25</Text> due September 15, 2020
+        </Paragraph>
+      </RadioCard>
+    </FlexGrid.Col>
+    <FlexGrid.Col xs={12} md={4}>
+      <RadioCard
+        label="3 installment payments"
+        name="papn"
+        value="3payment"
+        fullHeight={true}
+        checked={state.choice === '3payment'}
+        onChange={setChoice}
+      >
+        <Box below={3} />
+        <Paragraph>
+          <Text bold={true}>$68.83</Text> due August 15, 2020
+        </Paragraph>
+        <Paragraph>
+          <Text bold={true}>$68.83</Text> due September 15, 2020
+        </Paragraph>
+        <Paragraph>
+          <Text bold={true}>$68.83</Text> due October 15, 2020
+        </Paragraph>
+      </RadioCard>
+    </FlexGrid.Col>
+  </FlexGrid.Row>
+</FlexGrid>
 ```
 
 ### Variants
@@ -57,26 +80,21 @@ const setChoice = event => {
 By default, RadioCards will be displayed in the `standard` variant.
 
 ```jsx
-<RadioCard
-  label="1 line selection"
-  name="selection"
-  value="selection"
-  width={240}
-  height={90}
-  checked={true}
-/>
+<div style={{ width: '240px' }}>
+  <RadioCard label="1 line selection" name="selection" value="selection" checked={true} />
+</div>
 ```
 
 The `brand` variant.
 
 ```jsx
-<RadioCard
-  label="2 line selection"
-  name="selection2"
-  value="selection2"
-  variant="brand"
-  width={240}
-  height={90}
-  checked={true}
-/>
+<div style={{ width: '240px' }}>
+  <RadioCard
+    label="2 line selection"
+    name="selection2"
+    value="selection2"
+    variant="brand"
+    checked={true}
+  />
+</div>
 ```

--- a/packages/RadioCard/RadioCard.md
+++ b/packages/RadioCard/RadioCard.md
@@ -5,7 +5,7 @@ Similar to `Radio` buttons, `RadioCards` are used when there is a list of two or
 - All `RadioCards` within a group should have the same height and width
 - Use the `fullHeight` prop to have the bottom edge of the `RadioCards` aligned. This is usually needed when using cards in a `FlexGrid` and will result in the `RadioCards` matching the height of their parent container
 - The state of the RadioCards should be controlled, and as such both a `checked` and an `onChange` prop should be passed to each RadioCard
-- For accessibility, `RadioCards` should be grouped using a `<fieldset>`tag with a `<legend>` tag to define a caption
+- For accessibility, `RadioCards` should be grouped using a `<fieldset>` tag with a `<legend>` tag to define a caption
 - Avoid nesting interactive elements as `children` and additional details provided as `children` to the `RadioCard` should maintain a limit of 150 characters
 
 ```jsx

--- a/packages/RadioCard/RadioCard.md
+++ b/packages/RadioCard/RadioCard.md
@@ -3,8 +3,10 @@ Similar to `Radio` buttons, `RadioCards` are used when there is a list of two or
 ### Usage criteria
 
 - All `RadioCards` within a group should have the same height and width
-- Use the `fullHeight` prop to have the bottom edge of the `RadioCards` aligned. This is usually needed when using cards in a `FlexGrid` and will result in the `RadioCards` matching the height of their parent
+- Use the `fullHeight` prop to have the bottom edge of the `RadioCards` aligned. This is usually needed when using cards in a `FlexGrid` and will result in the `RadioCards` matching the height of their parent container
 - The state of the RadioCards should be controlled, and as such both a `checked` and an `onChange` prop should be passed to each RadioCard
+- For accessibility, `RadioCards` should be grouped using a `<fieldset>`tag with a `<legend>` tag to define a caption
+- Avoid nesting interactive elements as `children` and additional details provided as `children` to the `RadioCard` should maintain a limit of 150 characters
 
 ```jsx
 initialState = {
@@ -15,64 +17,71 @@ const setChoice = event => {
   setState({ choice: event.target.value })
 }
 
-;<FlexGrid>
-  <FlexGrid.Row>
-    <FlexGrid.Col xs={12} md={4}>
-      <RadioCard
-        label="1 installment payment"
-        name="papn"
-        value="1payment"
-        fullHeight={true}
-        checked={state.choice === '1payment'}
-        onChange={setChoice}
-      >
-        <Box below={3} />
-        <Paragraph>
-          <Text bold={true}>$206.50</Text> due August 15, 2020
-        </Paragraph>
-      </RadioCard>
-    </FlexGrid.Col>
-    <FlexGrid.Col xs={12} md={4}>
-      <RadioCard
-        label="2 installment payments"
-        name="papn"
-        value="2payment"
-        fullHeight={true}
-        checked={state.choice === '2payment'}
-        onChange={setChoice}
-      >
-        <Box below={3} />
-        <Paragraph>
-          <Text bold={true}>$103.25</Text> due August 15, 2020
-        </Paragraph>
-        <Paragraph>
-          <Text bold={true}>$103.25</Text> due September 15, 2020
-        </Paragraph>
-      </RadioCard>
-    </FlexGrid.Col>
-    <FlexGrid.Col xs={12} md={4}>
-      <RadioCard
-        label="3 installment payments"
-        name="papn"
-        value="3payment"
-        fullHeight={true}
-        checked={state.choice === '3payment'}
-        onChange={setChoice}
-      >
-        <Box below={3} />
-        <Paragraph>
-          <Text bold={true}>$68.83</Text> due August 15, 2020
-        </Paragraph>
-        <Paragraph>
-          <Text bold={true}>$68.83</Text> due September 15, 2020
-        </Paragraph>
-        <Paragraph>
-          <Text bold={true}>$68.83</Text> due October 15, 2020
-        </Paragraph>
-      </RadioCard>
-    </FlexGrid.Col>
-  </FlexGrid.Row>
-</FlexGrid>
+;<Box tag="fieldset" between={3}>
+  <legend>
+    <Text bold size="medium">
+      Select your preferred payment arrangement:
+    </Text>
+  </legend>
+  <FlexGrid>
+    <FlexGrid.Row>
+      <FlexGrid.Col xs={12} md={4}>
+        <RadioCard
+          label="1 installment payment"
+          name="papn"
+          value="1payment"
+          fullHeight={true}
+          checked={state.choice === '1payment'}
+          onChange={setChoice}
+        >
+          <Box below={3} />
+          <Paragraph>
+            <Text bold={true}>$206.50</Text> due August 15, 2020
+          </Paragraph>
+        </RadioCard>
+      </FlexGrid.Col>
+      <FlexGrid.Col xs={12} md={4}>
+        <RadioCard
+          label="2 installment payments"
+          name="papn"
+          value="2payment"
+          fullHeight={true}
+          checked={state.choice === '2payment'}
+          onChange={setChoice}
+        >
+          <Box below={3} />
+          <Paragraph>
+            <Text bold={true}>$103.25</Text> due August 15, 2020
+          </Paragraph>
+          <Paragraph>
+            <Text bold={true}>$103.25</Text> due September 15, 2020
+          </Paragraph>
+        </RadioCard>
+      </FlexGrid.Col>
+      <FlexGrid.Col xs={12} md={4}>
+        <RadioCard
+          label="3 installment payments"
+          name="papn"
+          value="3payment"
+          fullHeight={true}
+          checked={state.choice === '3payment'}
+          onChange={setChoice}
+        >
+          <Box below={3} />
+          <Paragraph>
+            <Text bold={true}>$68.83</Text> due August 15, 2020
+          </Paragraph>
+          <Paragraph>
+            <Text bold={true}>$68.83</Text> due September 15, 2020
+          </Paragraph>
+          <Paragraph>
+            <Text bold={true}>$68.83</Text> due October 15, 2020
+          </Paragraph>
+        </RadioCard>
+      </FlexGrid.Col>
+    </FlexGrid.Row>
+  </FlexGrid>
+</Box>
 ```
 
 ### Variants

--- a/packages/RadioCard/__tests__/RadioCard.spec.jsx
+++ b/packages/RadioCard/__tests__/RadioCard.spec.jsx
@@ -9,18 +9,13 @@ describe('RadioCard', () => {
     label: 'The radio',
     name: 'radio_group',
     value: 'the-value',
-    width: 200,
-    height: 200,
+    fullHeight: true,
+    checked: true,
+    readOnly: true,
   }
   const doShallow = () =>
     shallow(
-      <RadioCard
-        label="1 installment payment"
-        name="papn"
-        value="1payment"
-        width={315}
-        height={218}
-      >
+      <RadioCard {...defaultProps}>
         <Box vertical={3}>
           <Paragraph>$206.50 due August 15, 2020</Paragraph>
         </Box>

--- a/packages/RadioCard/__tests__/RadioCard.spec.jsx
+++ b/packages/RadioCard/__tests__/RadioCard.spec.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import Box from '@tds/core-box'
+import Paragraph from '@tds/core-paragraph'
+import RadioCard from '../RadioCard'
+
+describe('RadioCard', () => {
+  const defaultProps = {
+    label: 'The radio',
+    name: 'radio_group',
+    value: 'the-value',
+    width: 200,
+    height: 200,
+  }
+  const doShallow = () =>
+    shallow(
+      <RadioCard
+        label="1 installment payment"
+        name="papn"
+        value="1payment"
+        width={315}
+        height={218}
+      >
+        <Box vertical={3}>
+          <Paragraph>$206.50 due August 15, 2020</Paragraph>
+        </Box>
+      </RadioCard>
+    )
+
+  const doMount = (overrides = {}) => {
+    const radioCard = mount(
+      <RadioCard {...defaultProps} {...overrides}>
+        <Box vertical={3}>
+          <Paragraph>$206.50 due August 15, 2020</Paragraph>
+        </Box>
+      </RadioCard>
+    )
+
+    const findRadioElement = () => radioCard.find('[data-testid="hidden-input"]').find('input')
+
+    return {
+      radioCard,
+      findRadioElement,
+      findFakeRadio: () => radioCard.find('[data-testid="fake-input"]'),
+      label: radioCard.find('label'),
+    }
+  }
+
+  it('renders', () => {
+    const radioCard = doShallow()
+
+    expect(radioCard).toMatchSnapshot()
+  })
+
+  it('renders children', () => {
+    const { radioCard } = doMount()
+    expect(radioCard.find('Paragraph').exists()).toBeTruthy()
+    expect(
+      radioCard
+        .find('Paragraph')
+        .children()
+        .text()
+    ).toEqual('$206.50 due August 15, 2020')
+  })
+
+  it('has a fake radio', () => {
+    const { findFakeRadio } = doMount()
+    expect(findFakeRadio()).toMatchSnapshot()
+  })
+
+  it('must have a label', () => {
+    const { label } = doMount({ label: 'Some label' })
+    expect(label).toMatchSnapshot()
+  })
+
+  describe('connecting the label to the radio', () => {
+    it('connects the label to the radio', () => {
+      const { label, findRadioElement } = doMount()
+
+      expect(label.prop('htmlFor')).toEqual(findRadioElement().prop('id'))
+    })
+
+    it('uses the id when provided', () => {
+      const { label, findRadioElement } = doMount({
+        id: 'the-id',
+        name: 'the-radio-group',
+        value: 'the-value',
+      })
+
+      expect(label).toHaveProp('htmlFor', 'the-id')
+      expect(findRadioElement()).toHaveProp('id', 'the-id')
+    })
+
+    it('uses the name and the value when no id is provided', () => {
+      const { label, findRadioElement } = doMount({ name: 'the-radio-group', value: 'the-value' })
+
+      expect(label).toHaveProp('htmlFor', 'the-radio-group_the-value')
+      expect(findRadioElement()).toHaveProp('id', 'the-radio-group_the-value')
+    })
+  })
+
+  it('passes additional attributes to the radio', () => {
+    const { findRadioElement } = doMount({
+      'data-some-attr': 'some value',
+    })
+
+    expect(findRadioElement()).toHaveProp('data-some-attr', 'some value')
+  })
+
+  it('does not allow custom CSS', () => {
+    const { findRadioElement } = doMount({
+      className: 'my-custom-class',
+      style: { color: 'hotpink' },
+    })
+
+    expect(findRadioElement()).not.toHaveProp('className', 'my-custom-class')
+    expect(findRadioElement()).not.toHaveProp('style')
+  })
+})

--- a/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
+++ b/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
@@ -593,6 +593,9 @@ exports[`RadioCard must have a label 1`] = `
   .c0 {
     -webkit-transition: none !important;
     transition: none !important;
+    -webkit-transform: none !important;
+    -ms-transform: none !important;
+    transform: none !important;
   }
 }
 

--- a/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
+++ b/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
@@ -1093,21 +1093,21 @@ exports[`RadioCard must have a label 1`] = `
 
 exports[`RadioCard renders 1`] = `
 <RadioCard__StyledDiv
-  fullHeight={false}
+  fullHeight={true}
 >
   <RadioCard__HiddenInput
+    checked={true}
     data-testid="hidden-input"
-    height={218}
-    id="papn_1payment"
-    name="papn"
+    id="radiogroup_the-value"
+    name="radio_group"
+    readOnly={true}
     type="radio"
-    value="1payment"
+    value="the-value"
     variant="standard"
-    width={315}
   />
   <RadioCard__StyledLabel
     data-testid="checkbox-label"
-    htmlFor="papn_1payment"
+    htmlFor="radiogroup_the-value"
     variant="standard"
   >
     <RadioCard__StyledLabelBox
@@ -1128,7 +1128,7 @@ exports[`RadioCard renders 1`] = `
           invert={false}
           level="h3"
         >
-          1 installment payment
+          The radio
         </Heading>
       </Box>
       <RadioCard__StyledChildrenBox>

--- a/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
+++ b/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
@@ -536,6 +536,7 @@ exports[`RadioCard must have a label 1`] = `
 
 .c0:active {
   border: 0.0625rem solid #2B8000;
+  box-shadow: 0 0 0 0.0625rem #2B8000,0 0 0 0.125rem #FFFFFF inset,0 0 0 0.1875rem #2B8000 inset !important;
   background: #f4f9f2;
 }
 

--- a/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
+++ b/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
@@ -1,0 +1,1150 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioCard has a fake radio 1`] = `
+Array [
+  .c1 {
+  height: 1.25rem;
+  width: 1.25rem;
+  min-height: 1.25rem;
+  min-width: 1.25rem;
+  outline: 0;
+  line-height: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.3rem;
+  -webkit-transition: border-color 0.1s linear,background-color 0.1s linear;
+  transition: border-color 0.1s linear,background-color 0.1s linear;
+  border-radius: 50%;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #54595f;
+  background-color: #fff;
+}
+
+.c1 > i {
+  display: none;
+}
+
+.c4:focus ~ .c3 > div > div > .c0 {
+  box-shadow: 0 0 4px 1px #54595f;
+  border-color: #fff;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 {
+  border-color: #54595f;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 > span {
+  display: block;
+}
+
+.c2 {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: #2B8000;
+  display: none;
+}
+
+<RadioCard__FakeRadio
+    data-testid="fake-input"
+  >
+    <StyledComponent
+      data-testid="fake-input"
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "c0",
+            "isStatic": false,
+            "lastClassName": "c1",
+            "rules": Array [
+              "height: 1.25rem;",
+              "width: 1.25rem;",
+              "min-height: 1.25rem;",
+              "min-width: 1.25rem;",
+              "outline: 0;",
+              "line-height: 0;",
+              "display: flex;",
+              "align-items: center;",
+              "justify-content: center;",
+              "cursor: pointer;",
+              "margin-top: 0.3rem;",
+              "transition: border-color 0.1s linear, background-color 0.1s linear;",
+              "border-radius: 50%;",
+              "border-width: 1px;",
+              "border-style: solid;",
+              "border-color: #54595f;",
+              "background-color: #fff;",
+              "& > i {",
+              "display: none;",
+              "}",
+            ],
+          },
+          "displayName": "RadioCard__FakeRadio",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "c0",
+          "target": "span",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <span
+        className="c0 c1"
+        data-testid="fake-input"
+      >
+        <RadioCard__InnerChecked>
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+                  "isStatic": false,
+                  "lastClassName": "c2",
+                  "rules": Array [
+                    "width: 0.75rem;",
+                    "height: 0.75rem;",
+                    "border-radius: 50%;",
+                    "background-color: #2B8000;",
+                    "display: none;",
+                  ],
+                },
+                "displayName": "RadioCard__InnerChecked",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+                "target": "span",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+          >
+            <span
+              className="c2"
+            />
+          </StyledComponent>
+        </RadioCard__InnerChecked>
+      </span>
+    </StyledComponent>
+  </RadioCard__FakeRadio>,
+  .c1 {
+  height: 1.25rem;
+  width: 1.25rem;
+  min-height: 1.25rem;
+  min-width: 1.25rem;
+  outline: 0;
+  line-height: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.3rem;
+  -webkit-transition: border-color 0.1s linear,background-color 0.1s linear;
+  transition: border-color 0.1s linear,background-color 0.1s linear;
+  border-radius: 50%;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #54595f;
+  background-color: #fff;
+}
+
+.c1 > i {
+  display: none;
+}
+
+.c4:focus ~ .c3 > div > div > .c0 {
+  box-shadow: 0 0 4px 1px #54595f;
+  border-color: #fff;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 {
+  border-color: #54595f;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 > span {
+  display: block;
+}
+
+.c2 {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: #2B8000;
+  display: none;
+}
+
+<StyledComponent
+    data-testid="fake-input"
+    forwardedComponent={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "attrs": Array [],
+        "componentStyle": ComponentStyle {
+          "componentId": "c0",
+          "isStatic": false,
+          "lastClassName": "c1",
+          "rules": Array [
+            "height: 1.25rem;",
+            "width: 1.25rem;",
+            "min-height: 1.25rem;",
+            "min-width: 1.25rem;",
+            "outline: 0;",
+            "line-height: 0;",
+            "display: flex;",
+            "align-items: center;",
+            "justify-content: center;",
+            "cursor: pointer;",
+            "margin-top: 0.3rem;",
+            "transition: border-color 0.1s linear, background-color 0.1s linear;",
+            "border-radius: 50%;",
+            "border-width: 1px;",
+            "border-style: solid;",
+            "border-color: #54595f;",
+            "background-color: #fff;",
+            "& > i {",
+            "display: none;",
+            "}",
+          ],
+        },
+        "displayName": "RadioCard__FakeRadio",
+        "foldedComponentIds": Array [],
+        "render": [Function],
+        "styledComponentId": "c0",
+        "target": "span",
+        "toString": [Function],
+        "warnTooManyClasses": [Function],
+        "withComponent": [Function],
+      }
+    }
+    forwardedRef={null}
+  >
+    <span
+      className="c0 c1"
+      data-testid="fake-input"
+    >
+      <RadioCard__InnerChecked>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+                "isStatic": false,
+                "lastClassName": "c2",
+                "rules": Array [
+                  "width: 0.75rem;",
+                  "height: 0.75rem;",
+                  "border-radius: 50%;",
+                  "background-color: #2B8000;",
+                  "display: none;",
+                ],
+              },
+              "displayName": "RadioCard__InnerChecked",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+              "target": "span",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <span
+            className="c2"
+          />
+        </StyledComponent>
+      </RadioCard__InnerChecked>
+    </span>
+  </StyledComponent>,
+  .c1 {
+  height: 1.25rem;
+  width: 1.25rem;
+  min-height: 1.25rem;
+  min-width: 1.25rem;
+  outline: 0;
+  line-height: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.3rem;
+  -webkit-transition: border-color 0.1s linear,background-color 0.1s linear;
+  transition: border-color 0.1s linear,background-color 0.1s linear;
+  border-radius: 50%;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #54595f;
+  background-color: #fff;
+}
+
+.c1 > i {
+  display: none;
+}
+
+.c4:focus ~ .c3 > div > div > .c0 {
+  box-shadow: 0 0 4px 1px #54595f;
+  border-color: #fff;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 {
+  border-color: #54595f;
+}
+
+.c4:checked ~ .c3 > div > div > .c0 > span {
+  display: block;
+}
+
+.c2 {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: #2B8000;
+  display: none;
+}
+
+<span
+    className="c0 c1"
+    data-testid="fake-input"
+  >
+    <RadioCard__InnerChecked>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+              "isStatic": false,
+              "lastClassName": "c2",
+              "rules": Array [
+                "width: 0.75rem;",
+                "height: 0.75rem;",
+                "border-radius: 50%;",
+                "background-color: #2B8000;",
+                "display: none;",
+              ],
+            },
+            "displayName": "RadioCard__InnerChecked",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+            "target": "span",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <span
+          className="c2"
+        />
+      </StyledComponent>
+    </RadioCard__InnerChecked>
+  </span>,
+]
+`;
+
+exports[`RadioCard must have a label 1`] = `
+.c2 {
+  display: block;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3 > *:not(:last-child) {
+  margin-right: 1rem;
+}
+
+.c9 {
+  display: block;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: block;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.c11 {
+  color: #2a2c2e;
+  word-wrap: break-word;
+  padding: 0;
+  margin: 0;
+  word-wrap: break-word;
+  font-size: 1rem;
+  -webkit-letter-spacing: -0.8px;
+  -moz-letter-spacing: -0.8px;
+  -ms-letter-spacing: -0.8px;
+  letter-spacing: -0.8px;
+  line-height: 1.5;
+  font-weight: 400;
+  text-align: left;
+}
+
+.c11 sup {
+  top: -0.5em;
+  font-size: 0.875rem;
+  position: relative;
+  vertical-align: baseline;
+  padding-left: 0.1em;
+}
+
+.c7 {
+  word-wrap: break-word;
+  color: #2a2c2e;
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 1.4;
+  -webkit-letter-spacing: -0.6px;
+  -moz-letter-spacing: -0.6px;
+  -ms-letter-spacing: -0.6px;
+  letter-spacing: -0.6px;
+}
+
+.c7 sup {
+  position: relative;
+  vertical-align: baseline;
+  padding-left: 0.1em;
+  font-size: 0.875rem;
+  top: -0.5em;
+}
+
+.c7 > span {
+  -webkit-letter-spacing: inherit;
+  -moz-letter-spacing: inherit;
+  -ms-letter-spacing: inherit;
+  letter-spacing: inherit;
+}
+
+.c5 {
+  height: 1.25rem;
+  width: 1.25rem;
+  min-height: 1.25rem;
+  min-width: 1.25rem;
+  outline: 0;
+  line-height: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.3rem;
+  -webkit-transition: border-color 0.1s linear,background-color 0.1s linear;
+  transition: border-color 0.1s linear,background-color 0.1s linear;
+  border-radius: 50%;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #54595f;
+  background-color: #fff;
+}
+
+.c5 > i {
+  display: none;
+}
+
+.c0 {
+  border-width: 0;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  height: 200px;
+  width: 200px;
+  border: 0.0625rem solid #d8d8d8;
+  box-shadow: 0 0 1rem 0 rgba(0,0,0,0.1);
+  background-color: #fff;
+  -webkit-transition: -webkit-transform 0.2s ease-in-out,background 0.2s,color 0.2s,border 0.2s ease;
+  -webkit-transition: transform 0.2s ease-in-out,background 0.2s,color 0.2s,border 0.2s ease;
+  transition: transform 0.2s ease-in-out,background 0.2s,color 0.2s,border 0.2s ease;
+}
+
+.c0:hover {
+  border: 0.0625rem solid #2B8000 !important;
+  box-shadow: 0 0 0 0.0625rem #2B8000 !important;
+}
+
+.c0:active {
+  border: 0.0625rem solid #2B8000;
+  background: #f4f9f2;
+}
+
+.c0:hover {
+  -webkit-transform: scale(1.025);
+  -ms-transform: scale(1.025);
+  transform: scale(1.025);
+}
+
+.c12:focus ~ .c0 > div > div > .c4 {
+  box-shadow: 0 0 4px 1px #54595f;
+  border-color: #fff;
+}
+
+.c12:checked ~ .c0 > div > div > .c4 {
+  border-color: #54595f;
+}
+
+.c12:checked ~ .c0 > div > div > .c4 > span {
+  display: block;
+}
+
+.c6 {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: #2B8000;
+  display: none;
+}
+
+.c1 {
+  width: 100%;
+  margin-right: 0.5rem;
+}
+
+.c8 {
+  margin-left: 2.25rem;
+}
+
+@media (max-width:767px) {
+  .c2 {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c0 {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    margin-right: 1rem;
+  }
+}
+
+<label
+  className="c0"
+  data-testid="checkbox-label"
+  height={200}
+  htmlFor="radiogroup_the-value"
+  width={200}
+>
+  <RadioCard__StyledLabelBox
+    horizontal={3}
+    vertical={4}
+  >
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "RadioCard__StyledLabelBox-sc-17k3pnw-4",
+            "isStatic": false,
+            "lastClassName": "c1",
+            "rules": Array [
+              "width: 100%;",
+              "margin-right: 0.5rem;",
+              "@media (min-width: 768px) {",
+              "margin-right: 1rem;",
+              "}",
+            ],
+          },
+          "displayName": "RadioCard__StyledLabelBox",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "RadioCard__StyledLabelBox-sc-17k3pnw-4",
+          "target": [Function],
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      horizontal={3}
+      vertical={4}
+    >
+      <Box
+        className="c1"
+        horizontal={3}
+        inline={false}
+        tag="div"
+        vertical={4}
+      >
+        <styled.div
+          className="c1"
+          horizontal={3}
+          inline={false}
+          tag="div"
+          vertical={4}
+        >
+          <StyledComponent
+            className="c1"
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [
+                  [Function],
+                ],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bdVaJa",
+                  "isStatic": false,
+                  "lastClassName": "c10",
+                  "rules": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-bdVaJa",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            horizontal={3}
+            inline={false}
+            tag="div"
+            vertical={4}
+          >
+            <div
+              className="c2 c1 RadioCard__StyledLabelBox-sc-17k3pnw-4 c1"
+            >
+              <Box
+                between={3}
+                inline={true}
+                tag="div"
+              >
+                <styled.div
+                  between={3}
+                  inline={true}
+                  tag="div"
+                >
+                  <StyledComponent
+                    between={3}
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [
+                          [Function],
+                        ],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "sc-bdVaJa",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                            [Function],
+                          ],
+                        },
+                        "displayName": "styled.div",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "sc-bdVaJa",
+                        "target": "div",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    inline={true}
+                    tag="div"
+                  >
+                    <div
+                      className="c3"
+                    >
+                      <RadioCard__FakeRadio
+                        data-testid="fake-input"
+                      >
+                        <StyledComponent
+                          data-testid="fake-input"
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "c4",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  "height: 1.25rem;",
+                                  "width: 1.25rem;",
+                                  "min-height: 1.25rem;",
+                                  "min-width: 1.25rem;",
+                                  "outline: 0;",
+                                  "line-height: 0;",
+                                  "display: flex;",
+                                  "align-items: center;",
+                                  "justify-content: center;",
+                                  "cursor: pointer;",
+                                  "margin-top: 0.3rem;",
+                                  "transition: border-color 0.1s linear, background-color 0.1s linear;",
+                                  "border-radius: 50%;",
+                                  "border-width: 1px;",
+                                  "border-style: solid;",
+                                  "border-color: #54595f;",
+                                  "background-color: #fff;",
+                                  "& > i {",
+                                  "display: none;",
+                                  "}",
+                                ],
+                              },
+                              "displayName": "RadioCard__FakeRadio",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "c4",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c4 c5"
+                            data-testid="fake-input"
+                          >
+                            <RadioCard__InnerChecked>
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+                                      "isStatic": false,
+                                      "lastClassName": "c6",
+                                      "rules": Array [
+                                        "width: 0.75rem;",
+                                        "height: 0.75rem;",
+                                        "border-radius: 50%;",
+                                        "background-color: #2B8000;",
+                                        "display: none;",
+                                      ],
+                                    },
+                                    "displayName": "RadioCard__InnerChecked",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "RadioCard__InnerChecked-sc-17k3pnw-3",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                              >
+                                <span
+                                  className="c6"
+                                />
+                              </StyledComponent>
+                            </RadioCard__InnerChecked>
+                          </span>
+                        </StyledComponent>
+                      </RadioCard__FakeRadio>
+                      <Heading
+                        invert={false}
+                        level="h3"
+                      >
+                        <Heading__StyledHeading
+                          as="h3"
+                          data-testid="heading"
+                          invert={false}
+                          level="h3"
+                        >
+                          <StyledComponent
+                            as="h3"
+                            data-testid="heading"
+                            forwardedComponent={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "attrs": Array [],
+                                "componentStyle": ComponentStyle {
+                                  "componentId": "Heading__StyledHeading-mpz92r-0",
+                                  "isStatic": false,
+                                  "lastClassName": "c7",
+                                  "rules": Array [
+                                    "word-wrap: break-word;",
+                                    [Function],
+                                  ],
+                                },
+                                "displayName": "Heading__StyledHeading",
+                                "foldedComponentIds": Array [],
+                                "render": [Function],
+                                "styledComponentId": "Heading__StyledHeading-mpz92r-0",
+                                "target": "h1",
+                                "toString": [Function],
+                                "warnTooManyClasses": [Function],
+                                "withComponent": [Function],
+                              }
+                            }
+                            forwardedRef={null}
+                            invert={false}
+                            level="h3"
+                          >
+                            <h3
+                              className="c7"
+                              data-testid="heading"
+                            >
+                              Some label
+                            </h3>
+                          </StyledComponent>
+                        </Heading__StyledHeading>
+                      </Heading>
+                    </div>
+                  </StyledComponent>
+                </styled.div>
+              </Box>
+              <RadioCard__StyledChildrenBox>
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "RadioCard__StyledChildrenBox-sc-17k3pnw-5",
+                        "isStatic": false,
+                        "lastClassName": "c8",
+                        "rules": Array [
+                          "margin-left: 2.25rem;",
+                        ],
+                      },
+                      "displayName": "RadioCard__StyledChildrenBox",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "RadioCard__StyledChildrenBox-sc-17k3pnw-5",
+                      "target": [Function],
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                >
+                  <Box
+                    className="c8"
+                    inline={false}
+                    tag="div"
+                  >
+                    <styled.div
+                      className="c8"
+                      inline={false}
+                      tag="div"
+                    >
+                      <StyledComponent
+                        className="c8"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [
+                              [Function],
+                            ],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-bdVaJa",
+                              "isStatic": false,
+                              "lastClassName": "c10",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                              ],
+                            },
+                            "displayName": "styled.div",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "sc-bdVaJa",
+                            "target": "div",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        inline={false}
+                        tag="div"
+                      >
+                        <div
+                          className="c9 c8 RadioCard__StyledChildrenBox-sc-17k3pnw-5 c8"
+                        >
+                          <Box
+                            inline={false}
+                            tag="div"
+                            vertical={3}
+                          >
+                            <styled.div
+                              inline={false}
+                              tag="div"
+                              vertical={3}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [
+                                      [Function],
+                                    ],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-bdVaJa",
+                                      "isStatic": false,
+                                      "lastClassName": "c10",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "styled.div",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-bdVaJa",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                inline={false}
+                                tag="div"
+                                vertical={3}
+                              >
+                                <div
+                                  className="c10"
+                                >
+                                  <Paragraph
+                                    align="left"
+                                    bold={false}
+                                    invert={false}
+                                    size="medium"
+                                  >
+                                    <Paragraph__StyledParagraph
+                                      align="left"
+                                      bold={false}
+                                      invert={false}
+                                      size="medium"
+                                    >
+                                      <StyledComponent
+                                        align="left"
+                                        bold={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Paragraph__StyledParagraph-efl81j-0",
+                                              "isStatic": false,
+                                              "lastClassName": "c11",
+                                              "rules": Array [
+                                                [Function],
+                                                "word-wrap: break-word;",
+                                                "padding: 0;",
+                                                "margin: 0;",
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                "sup {",
+                                                "top: -0.5em;",
+                                                "font-size: 0.875rem;",
+                                                "position: relative;",
+                                                "vertical-align: baseline;",
+                                                "padding-left: 0.1em;",
+                                                "}",
+                                              ],
+                                            },
+                                            "displayName": "Paragraph__StyledParagraph",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Paragraph__StyledParagraph-efl81j-0",
+                                            "target": "p",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        invert={false}
+                                        size="medium"
+                                      >
+                                        <p
+                                          className="c11"
+                                          size="medium"
+                                        >
+                                          $206.50 due August 15, 2020
+                                        </p>
+                                      </StyledComponent>
+                                    </Paragraph__StyledParagraph>
+                                  </Paragraph>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </Box>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </Box>
+                </StyledComponent>
+              </RadioCard__StyledChildrenBox>
+            </div>
+          </StyledComponent>
+        </styled.div>
+      </Box>
+    </StyledComponent>
+  </RadioCard__StyledLabelBox>
+</label>
+`;
+
+exports[`RadioCard renders 1`] = `
+<div>
+  <RadioCard__HiddenInput
+    data-testid="hidden-input"
+    id="papn_1payment"
+    name="papn"
+    type="radio"
+    value="1payment"
+    variant="standard"
+  />
+  <RadioCard__StyledLabel
+    data-testid="checkbox-label"
+    height={218}
+    htmlFor="papn_1payment"
+    variant="standard"
+    width={315}
+  >
+    <RadioCard__StyledLabelBox
+      horizontal={3}
+      vertical={4}
+    >
+      <Box
+        between={3}
+        inline={true}
+        tag="div"
+      >
+        <RadioCard__FakeRadio
+          data-testid="fake-input"
+        >
+          <RadioCard__InnerChecked />
+        </RadioCard__FakeRadio>
+        <Heading
+          invert={false}
+          level="h3"
+        >
+          1 installment payment
+        </Heading>
+      </Box>
+      <RadioCard__StyledChildrenBox>
+        <Box
+          inline={false}
+          tag="div"
+          vertical={3}
+        >
+          <Paragraph
+            align="left"
+            bold={false}
+            invert={false}
+            size="medium"
+          >
+            $206.50 due August 15, 2020
+          </Paragraph>
+        </Box>
+      </RadioCard__StyledChildrenBox>
+    </RadioCard__StyledLabelBox>
+  </RadioCard__StyledLabel>
+</div>
+`;

--- a/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
+++ b/packages/RadioCard/__tests__/__snapshots__/RadioCard.spec.jsx.snap
@@ -519,8 +519,7 @@ exports[`RadioCard must have a label 1`] = `
   display: -ms-flexbox;
   display: flex;
   cursor: pointer;
-  height: 200px;
-  width: 200px;
+  height: 100%;
   border: 0.0625rem solid #d8d8d8;
   box-shadow: 0 0 1rem 0 rgba(0,0,0,0.1);
   background-color: #fff;
@@ -606,9 +605,7 @@ exports[`RadioCard must have a label 1`] = `
 <label
   className="c0"
   data-testid="checkbox-label"
-  height={200}
   htmlFor="radiogroup_the-value"
-  width={200}
 >
   <RadioCard__StyledLabelBox
     horizontal={3}
@@ -1092,21 +1089,23 @@ exports[`RadioCard must have a label 1`] = `
 `;
 
 exports[`RadioCard renders 1`] = `
-<div>
+<RadioCard__StyledDiv
+  fullHeight={false}
+>
   <RadioCard__HiddenInput
     data-testid="hidden-input"
+    height={218}
     id="papn_1payment"
     name="papn"
     type="radio"
     value="1payment"
     variant="standard"
+    width={315}
   />
   <RadioCard__StyledLabel
     data-testid="checkbox-label"
-    height={218}
     htmlFor="papn_1payment"
     variant="standard"
-    width={315}
   >
     <RadioCard__StyledLabelBox
       horizontal={3}
@@ -1147,5 +1146,5 @@ exports[`RadioCard renders 1`] = `
       </RadioCard__StyledChildrenBox>
     </RadioCard__StyledLabelBox>
   </RadioCard__StyledLabel>
-</div>
+</RadioCard__StyledDiv>
 `;

--- a/packages/RadioCard/index.cjs.js
+++ b/packages/RadioCard/index.cjs.js
@@ -1,0 +1,3 @@
+const RadioCard = require('./dist/index.cjs')
+
+module.exports = RadioCard

--- a/packages/RadioCard/index.es.js
+++ b/packages/RadioCard/index.es.js
@@ -1,0 +1,3 @@
+import RadioCard from './dist/index.es'
+
+export default RadioCard

--- a/packages/RadioCard/package.json
+++ b/packages/RadioCard/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "styled-components": "^4.1.3"
+    "styled-components": "^4.1.3 || ^5.1.0"
   },
   "dependencies": {
     "@tds/core-box": "^2.1.3",
@@ -32,5 +32,8 @@
     "@tds/util-helpers": "^1.5.0",
     "@tds/shared-styles": "^1.5.2",
     "prop-types": "^15.6.2"
+  },
+  "devDependencies": {
+    "@tds/core-paragraph": "^2.0.12"
   }
 }

--- a/packages/RadioCard/package.json
+++ b/packages/RadioCard/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tds/community-radio-card",
+  "version": "0.1.0-0",
+  "description": "",
+  "main": "index.cjs.js",
+  "module": "index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/telus/tds-community.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "TELUS digital",
+  "engines": {
+    "node": ">=8"
+  },
+  "bugs": {
+    "url": "https://github.com/telus/tds-community/issues"
+  },
+  "homepage": "http://tds.telus.com",
+  "peerDependencies": {
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2",
+    "styled-components": "^4.1.3"
+  },
+  "dependencies": {
+    "@tds/core-box": "^2.1.3",
+    "@tds/core-colours": "^2.2.1",
+    "@tds/core-heading": "^3.0.4",
+    "@tds/util-helpers": "^1.5.0",
+    "@tds/shared-styles": "^1.5.2",
+    "prop-types": "^15.6.2"
+  }
+}

--- a/packages/RadioCard/rollup.config.js
+++ b/packages/RadioCard/rollup.config.js
@@ -1,0 +1,7 @@
+import configure from '../../config/rollup.config'
+import { dependencies } from './package.json'
+
+export default configure({
+  input: './RadioCard.jsx',
+  dependencies,
+})

--- a/shared/utils/generateId/__tests__/generateId.spec.js
+++ b/shared/utils/generateId/__tests__/generateId.spec.js
@@ -1,0 +1,41 @@
+import generateId from '../generateId'
+
+describe('generateId', () => {
+  it('picks the first non empty value', () => {
+    const id = generateId(undefined, null, '', '1', 'two')
+
+    expect(id.identity()).toEqual('1')
+  })
+
+  describe('sanitization', () => {
+    it('lowercases all characters', () => {
+      const id = generateId('ALLCAPS')
+
+      expect(id.identity()).toEqual('allcaps')
+    })
+
+    it('handles numbers', () => {
+      const id = generateId(1)
+
+      expect(id.identity()).toEqual('1')
+    })
+
+    it('replaces spaces with dashes', () => {
+      const id = generateId('an id with spaces')
+
+      expect(id.identity()).toEqual('an-id-with-spaces')
+    })
+
+    it('only preserves characters and numbers', () => {
+      const id = generateId('an id with invalid characters :"/*123')
+
+      expect(id.identity()).toEqual('an-id-with-invalid-characters-123')
+    })
+  })
+
+  it('can add postfixes', () => {
+    const id = generateId('my-id')
+
+    expect(id.postfix('a postfix')).toEqual('my-id_a-postfix')
+  })
+})

--- a/shared/utils/generateId/generateId.js
+++ b/shared/utils/generateId/generateId.js
@@ -1,0 +1,19 @@
+import find from 'array-find-es6'
+
+const sanitize = text =>
+  text
+    .toString()
+    .toLowerCase()
+    .replace(/ /g, '-')
+    .replace(/[^a-zA-Z0-9-]/g, '')
+
+const generateId = (...choices) => {
+  const id = sanitize(find(choices, choice => choice))
+
+  return {
+    identity: () => id,
+    postfix: value => `${id}_${sanitize(value)}`,
+  }
+}
+
+export default generateId

--- a/shared/utils/generateId/package.json
+++ b/shared/utils/generateId/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@tds/util-generate-id",
+  "version": "1.0.4",
+  "private": true,
+  "main": "",
+  "module": "",
+  "dependencies": {
+    "array-find-es6": "^2.0.3"
+  }
+}

--- a/shared/utils/generateId/package.json
+++ b/shared/utils/generateId/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tds/util-generate-id",
-  "version": "1.0.4",
+  "version": "1.0.0-0",
   "private": true,
   "main": "",
   "module": "",


### PR DESCRIPTION
Similar to `Radio` buttons, `RadioCards` are used when there is a list of two or more options that are mutually exclusive and the user must select exactly one choice. `RadioCards` allow users to easily compare and see options with greater detail. Clicking anywhere on the card selects that option.

- [x] Desk check was done with @Christina-Lo. 
- [x] Component was reviewed with the a11y team

[Invision Designs](https://telus.invisionapp.com/d/main#/console/13362811/429359831/preview)
[Design in context](https://telus.invisionapp.com/d/main#/console/13362811/429359832/preview)
[Jira Ticket](https://telusdigital.atlassian.net/browse/DJR-2730)

<img width="1009" alt="Screen Shot 2020-10-02 at 11 22 52 AM" src="https://user-images.githubusercontent.com/55095713/94940576-ac2fed80-04a1-11eb-9bf0-1fee4b1d4920.png">


