### PR TITLE
Quiet button (private component) update

### DIFF
--- a/packages/QuietButton/QuietButton.jsx
+++ b/packages/QuietButton/QuietButton.jsx
@@ -1,5 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
+import Box from '@tds/core-box'
+import {
+  colorGreyRaven,
+  colorWhite,
+  colorGreyShuttle,
+  colorGreyGainsboro,
+  colorGreyShark,
+} from '@tds/core-colours'
+import { componentWithName } from '@tds/util-prop-types'
 import { safeRest } from '@tds/util-helpers'
 import { small } from '@tds/shared-typography'
 import { borders } from '@tds/shared-styles'
@@ -7,29 +16,29 @@ import PropTypes from 'prop-types'
 
 const baseButton = {
   boxSizing: 'border-box',
-  margin: '2px',
-  padding: '0px 16px 0px 16px',
+  margin: '0.125rem',
+  padding: '0rem',
   cursor: 'pointer',
-  background: '#FFFFFF',
+  background: colorWhite,
   transition: 'all 0.2s ease-in-out',
-  minWidth: '44px',
-  height: '28px',
-  border: '1px solid #71757B',
+  minWidth: '2.75rem',
+  minHeight: '1.75rem',
+  border: `0.0625rem solid ${colorGreyRaven}`,
   position: 'relative',
-  borderRadius: '3px',
-  color: '#2A2C2E',
+  borderRadius: '0.1875rem',
+  color: colorGreyShark,
   '&:hover': {
-    boxShadow: '0 0 0 2px #71757B',
-    midWidth: '72px',
+    boxShadow: `0 0 0 0.125rem ${colorGreyRaven}`,
+    midWidth: '4.5rem',
   },
   '&:active': {
-    border: '1px solid #54595F',
-    boxShadow: '0 0 0 2px #54595F',
-    background: '#D8D8D8',
+    border: `0.0625rem solid ${colorGreyShuttle}`,
+    boxShadow: `0 0 0 0.125rem ${colorGreyShuttle}`,
+    background: colorGreyGainsboro,
   },
   '&:focus': {
-    background: '#FFFFFF',
-    boxShadow: '0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset, 0 0 0 3px #54595F inset',
+    background: colorWhite,
+    boxShadow: `0 0 0 0.125rem ${colorGreyRaven}, 0 0 0 0.125rem ${colorWhite} inset, 0 0 0 0.1875rem ${colorGreyShuttle} inset`,
     outline: 'none !important',
   },
   '@media (prefers-reduced-motion: reduce)': {
@@ -39,14 +48,13 @@ const baseButton = {
 const btnWrapper = {
   display: 'flex',
   flexDirection: 'row',
-  alignItems: 'center',
-  padding: '3px 0px 5px 0px',
+  padding: '0.1875rem 0rem 0.3125rem 0rem',
   '& svg': {
-    margin: '-3px 0 -5px 0',
+    margin: '-0.0625rem 0rem -0.4375rem 0rem',
   },
 }
 const spaceWrapper = {
-  paddingRight: '4px',
+  paddingRight: '0.25rem',
 }
 
 const StyledQuietButton = styled.button(baseButton, small, borders.rounded)
@@ -55,7 +63,7 @@ const SpaceWrapper = styled.div(spaceWrapper)
 
 const spaceFunction = childrenArray => {
   return childrenArray.map((child, index) => {
-    if (child.type && child.type.name !== 'A11yContent' && index === childrenArray.length - 1) {
+    if ((child.type && child.type.name === 'A11yContent') || index === childrenArray.length - 1) {
       return child
     }
     return <SpaceWrapper key={child || child.type.name}>{child}</SpaceWrapper>
@@ -72,7 +80,9 @@ const QuietButton = ({ children, ...rest }) => {
 
   return (
     <StyledQuietButton type="button" {...safeRest(rest)}>
-      <ButtonWrapper>{spaceFunction(childrenArray)}</ButtonWrapper>
+      <Box horizontal={3}>
+        <ButtonWrapper>{spaceFunction(childrenArray)}</ButtonWrapper>
+      </Box>
     </StyledQuietButton>
   )
 }
@@ -82,7 +92,16 @@ QuietButton.propTypes = {
    * Button children.
    */
 
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        componentWithName('A11yContent'),
+        componentWithName('Dependent', true),
+      ])
+    ),
+    PropTypes.string,
+  ]).isRequired,
 }
 
 export default QuietButton

--- a/packages/QuietButton/__tests__/QuietButton.spec.jsx
+++ b/packages/QuietButton/__tests__/QuietButton.spec.jsx
@@ -50,9 +50,9 @@ describe('QuietButton', () => {
   })
 
   it('should contain text', () => {
-    const button = shallow(<QuietButton>Text</QuietButton>)
-
-    expect(button.text()).toEqual('Text')
+    const quietButton = doMount()
+    expect(quietButton.text().includes('Words')).toBe(true)
+    quietButton.unmount()
   })
 
   it('should do something when clicked', () => {

--- a/packages/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
+++ b/packages/QuietButton/__tests__/__snapshots__/QuietButton.spec.jsx.snap
@@ -1,20 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QuietButton renders 1`] = `
+.c1 {
+  display: block;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 .c0 {
   box-sizing: border-box;
-  margin: 2px;
-  padding: 0px 16px 0px 16px;
+  margin: 0.125rem;
+  padding: 0rem;
   cursor: pointer;
-  background: #FFFFFF;
+  background: #fff;
   -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out;
-  min-width: 44px;
-  height: 28px;
-  border: 1px solid #71757B;
+  min-width: 2.75rem;
+  min-height: 1.75rem;
+  border: 0.0625rem solid #71757b;
   position: relative;
-  border-radius: 3px;
-  color: #2A2C2E;
+  border-radius: 0.1875rem;
+  color: #2a2c2e;
   word-wrap: break-word;
   font-size: 0.875rem;
   -webkit-letter-spacing: -0.6px;
@@ -26,23 +35,23 @@ exports[`QuietButton renders 1`] = `
 }
 
 .c0:hover {
-  box-shadow: 0 0 0 2px #71757B;
-  mid-width: 72px;
+  box-shadow: 0 0 0 0.125rem #71757b;
+  mid-width: 4.5rem;
 }
 
 .c0:active {
-  border: 1px solid #54595F;
-  box-shadow: 0 0 0 2px #54595F;
-  background: #D8D8D8;
+  border: 0.0625rem solid #54595f;
+  box-shadow: 0 0 0 0.125rem #54595f;
+  background: #d8d8d8;
 }
 
 .c0:focus {
-  background: #FFFFFF;
-  box-shadow: 0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset,0 0 0 3px #54595F inset;
+  background: #fff;
+  box-shadow: 0 0 0 0.125rem #71757b,0 0 0 0.125rem #fff inset,0 0 0 0.1875rem #54595f inset;
   outline: none !important;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -50,19 +59,11 @@ exports[`QuietButton renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 3px 0px 5px 0px;
+  padding: 0.1875rem 0rem 0.3125rem 0rem;
 }
 
-.c1 svg {
-  margin: -3px 0 -5px 0;
-}
-
-.c2 {
-  padding-right: 4px;
+.c2 svg {
+  margin: -0.0625rem 0rem -0.4375rem 0rem;
 }
 
 @media (prefers-reduced-motion:reduce) {
@@ -87,29 +88,29 @@ exports[`QuietButton renders 1`] = `
             "lastClassName": "c0",
             "rules": Array [
               "box-sizing: border-box;",
-              "margin: 2px;",
-              "padding: 0px 16px 0px 16px;",
+              "margin: 0.125rem;",
+              "padding: 0rem;",
               "cursor: pointer;",
-              "background: #FFFFFF;",
+              "background: #fff;",
               "transition: all 0.2s ease-in-out;",
-              "min-width: 44px;",
-              "height: 28px;",
-              "border: 1px solid #71757B;",
+              "min-width: 2.75rem;",
+              "min-height: 1.75rem;",
+              "border: 0.0625rem solid #71757b;",
               "position: relative;",
-              "border-radius: 3px;",
-              "color: #2A2C2E;",
+              "border-radius: 0.1875rem;",
+              "color: #2a2c2e;",
               "&:hover {",
-              "box-shadow: 0 0 0 2px #71757B;",
-              "mid-width: 72px;",
+              "box-shadow: 0 0 0 0.125rem #71757b;",
+              "mid-width: 4.5rem;",
               "}",
               "&:active {",
-              "border: 1px solid #54595F;",
-              "box-shadow: 0 0 0 2px #54595F;",
-              "background: #D8D8D8;",
+              "border: 0.0625rem solid #54595f;",
+              "box-shadow: 0 0 0 0.125rem #54595f;",
+              "background: #d8d8d8;",
               "}",
               "&:focus {",
-              "background: #FFFFFF;",
-              "box-shadow: 0 0 0 2px #71757B,0 0 0 2px #FFFFFF inset, 0 0 0 3px #54595F inset;",
+              "background: #fff;",
+              "box-shadow: 0 0 0 0.125rem #71757b, 0 0 0 0.125rem #fff inset, 0 0 0 0.1875rem #54595f inset;",
               "outline: none !important;",
               "}",
               "@media (prefers-reduced-motion: reduce) {",
@@ -139,79 +140,95 @@ exports[`QuietButton renders 1`] = `
         className="c0"
         type="button"
       >
-        <QuietButton__ButtonWrapper>
-          <StyledComponent
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
-                  "isStatic": false,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "display: flex;",
-                    "flex-direction: row;",
-                    "align-items: center;",
-                    "padding: 3px 0px 5px 0px;",
-                    "& svg {",
-                    "margin: -3px 0 -5px 0;",
-                    "}",
-                  ],
-                },
-                "displayName": "QuietButton__ButtonWrapper",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
+        <Box
+          horizontal={3}
+          inline={false}
+          tag="div"
+        >
+          <styled.div
+            horizontal={3}
+            inline={false}
+            tag="div"
           >
-            <div
-              className="c1"
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [
+                    [Function],
+                  ],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-EHOje",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-EHOje",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              horizontal={3}
+              inline={false}
+              tag="div"
             >
-              <QuietButton__SpaceWrapper
-                key="Words"
+              <div
+                className="c1"
               >
-                <StyledComponent
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "QuietButton__SpaceWrapper-sc-1anctzy-2",
-                        "isStatic": false,
-                        "lastClassName": "c2",
-                        "rules": Array [
-                          "padding-right: 4px;",
-                        ],
-                      },
-                      "displayName": "QuietButton__SpaceWrapper",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "QuietButton__SpaceWrapper-sc-1anctzy-2",
-                      "target": "div",
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
+                <QuietButton__ButtonWrapper>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "display: flex;",
+                            "flex-direction: row;",
+                            "padding: 0.1875rem 0rem 0.3125rem 0rem;",
+                            "& svg {",
+                            "margin: -0.0625rem 0rem -0.4375rem 0rem;",
+                            "}",
+                          ],
+                        },
+                        "displayName": "QuietButton__ButtonWrapper",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "QuietButton__ButtonWrapper-sc-1anctzy-1",
+                        "target": "div",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
                     }
-                  }
-                  forwardedRef={null}
-                >
-                  <div
-                    className="c2"
+                    forwardedRef={null}
                   >
-                    Words
-                  </div>
-                </StyledComponent>
-              </QuietButton__SpaceWrapper>
-            </div>
-          </StyledComponent>
-        </QuietButton__ButtonWrapper>
+                    <div
+                      className="c2"
+                    >
+                      Words
+                    </div>
+                  </StyledComponent>
+                </QuietButton__ButtonWrapper>
+              </div>
+            </StyledComponent>
+          </styled.div>
+        </Box>
       </button>
     </StyledComponent>
   </QuietButton__StyledQuietButton>

--- a/packages/QuietButton/package.json
+++ b/packages/QuietButton/package.json
@@ -26,9 +26,12 @@
     "styled-components": "^4.1.3"
   },
   "dependencies": {
+    "@tds/core-box": "^2.1.3",
+    "@tds/core-colours": "^2.2.1",
     "@tds/shared-styles": "^1.5.2",
     "@tds/shared-typography": "^1.3.5",
     "@tds/util-helpers": "^1.5.0",
+    "@tds/util-prop-types": "^1.4.0",
     "prop-types": "^15.6.2"
   }
 }


### PR DESCRIPTION
### **Description**

Update to quietButton (private component). (Screen shot below is zoomed in & in focus/active state)
<img width="312" alt="Screen Shot 2020-10-23 at 5 07 36 PM" src="https://user-images.githubusercontent.com/55095713/97201397-c7cca200-1788-11eb-934a-25d83c079e21.png">

Addresses [**issue #362** ](https://github.com/telus/tds-community/issues/362).
Also **fixes a bug in the space function** (previously padding was being incorrectly applied to A11yContent and right text).

#### The changes needed (as outlined in the opened issue) were as follows:

1. Change px units to rem units: **done.** 

2. Recommend Box instead of hard-coded padding: **done.**

- With regards to the vertical padding, the TDS component Box was not able to achieve this design as there is variable spacing on top and bottom of text (ie the text is not centre-aligned). This is mentioned in the designs and as such hard-coded vertical padding is required. See the [Invision design](https://telus.invisionapp.com/d/main#/console/13491097/419340834/preview).

3. Use core-colours instead of hard-coded colours: **done**
4. Consider not using cursor: pointer: **not done since as mentioned in the issue, a holistic effort across all buttons would be required.** 
5. Can leverage core-button prop types for A11yContent: **done**

#### Additional requests made:

6. Please use a minHeight for the Box in order to allow wrapping copy to have the border surround: **done.**
7. Ensure the icon, if used, lines up with the first word in case word wrapping occurs: **done. (See screenshot below)**

- **Note:** I nested the button in a div with a small fixed width to achieve this particular screen shot, different widths would look different with regards to how much text is on one line

<img width="356" alt="Screen Shot 2020-10-23 at 5 04 58 PM" src="https://user-images.githubusercontent.com/55095713/97200587-c77fd700-1787-11eb-9f28-d2883394e68e.png">

