### PR TITLE
feat(community-tabs): allow tabs to be controlled externally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3288,8 +3288,7 @@
     "@tds/core-colours": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@tds/core-colours/-/core-colours-2.2.1.tgz",
-      "integrity": "sha512-5ZW1Ru3LdlhFP2iU+n0fX6/5dlC6TT4l28XO88hRre0C81NtApVy+6pHVNpG+24VqQGCWG1LMG3/qkjnJvVrtw==",
-      "dev": true
+      "integrity": "sha512-5ZW1Ru3LdlhFP2iU+n0fX6/5dlC6TT4l28XO88hRre0C81NtApVy+6pHVNpG+24VqQGCWG1LMG3/qkjnJvVrtw=="
     },
     "@tds/core-css-reset": {
       "version": "2.0.5",
@@ -3305,11 +3304,54 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/@tds/core-decorative-icon/-/core-decorative-icon-2.6.4.tgz",
       "integrity": "sha512-hFPIQsOT2qBzmW4rmeuUHjfgVMnXksTrtACSkihiyhZGYiNbWEhloGbJfxu9zsY1nBB7fI3OipI13hnItMkntQ==",
-      "dev": true,
       "requires": {
         "@tds/core-colours": "^2.2.1",
         "@tds/util-helpers": "^1.4.2",
         "prop-types": "^15.5.10"
+      }
+    },
+    "@tds/core-dimple-divider": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@tds/core-dimple-divider/-/core-dimple-divider-2.0.16.tgz",
+      "integrity": "sha512-Df0YuaxHAwG0NY1uMfZm/wQifqbn48MyIIiuK6QxcMZmuHYUU2M3Fmt9seeH7/HxbztXzLlrdyhxJOUGaOGpbw==",
+      "dev": true,
+      "requires": {
+        "@tds/shared-styles": "^2.0.1",
+        "@tds/util-helpers": "^1.5.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@tds/core-responsive": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-responsive/-/core-responsive-1.3.4.tgz",
+          "integrity": "sha512-iGVxGxMcTXcBr9tMZ3/HQ/ytRoSUnoSZyE4w2mBNrkhNhPg7j7blJd2dnJYAFQe3era0YNbFOgf+CMmQHK2H3Q==",
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-media": "^1.10.0",
+            "sass-mq": "^5.0.0"
+          }
+        },
+        "@tds/shared-styles": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@tds/shared-styles/-/shared-styles-2.0.1.tgz",
+          "integrity": "sha512-aVEzRu8sfJoIG7Rjooxb77oFWzUwL/cB6DcfarCqfbRRsBO+/9RUR8hGea7CQQ8dLf8dYWAphGm5stOf/D0J3Q==",
+          "dev": true,
+          "requires": {
+            "@tds/core-colours": "^2.2.1",
+            "@tds/core-responsive": "^1.3.4",
+            "@tds/shared-typography": "^1.3.5"
+          }
+        },
+        "@tds/util-helpers": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/@tds/util-helpers/-/util-helpers-1.5.1.tgz",
+          "integrity": "sha512-D6ih5eGkh4eUQCJyjghV4O6bwVtBNpTcN7mv/tYgRUPSF3jiDJJ7gE1UZrvrtR3e6YXox62kmnEBE7iGD7NomA==",
+          "dev": true,
+          "requires": {
+            "@tds/core-responsive": "^1.3.4"
+          }
+        }
       }
     },
     "@tds/core-feedback-icon": {
@@ -3489,6 +3531,60 @@
         }
       }
     },
+    "@tds/core-interactive-icon": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@tds/core-interactive-icon/-/core-interactive-icon-2.1.1.tgz",
+      "integrity": "sha512-4QQ54wYGjmQonU0/0C85XgzIPfY5m/R8m6Jfc3e7GfYFxhyJFaW+UbVihr6iSyTGH1bPF+XtPXvuJ2bJ+6pXMw==",
+      "requires": {
+        "@tds/core-a11y-content": "^2.2.3",
+        "@tds/core-colours": "^2.2.1",
+        "@tds/core-text": "^3.1.4",
+        "@tds/shared-styles": "^2.0.1",
+        "@tds/util-helpers": "^1.5.1",
+        "@tds/util-prop-types": "^1.4.0",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@tds/core-responsive": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-responsive/-/core-responsive-1.3.4.tgz",
+          "integrity": "sha512-iGVxGxMcTXcBr9tMZ3/HQ/ytRoSUnoSZyE4w2mBNrkhNhPg7j7blJd2dnJYAFQe3era0YNbFOgf+CMmQHK2H3Q==",
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-media": "^1.10.0",
+            "sass-mq": "^5.0.0"
+          }
+        },
+        "@tds/core-text": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-text/-/core-text-3.1.4.tgz",
+          "integrity": "sha512-/obC/u2d4+gafHCMoI4+NBu7q+fqHZmH+aNxaXOA42wm5QWE6LPegkV7f236yvK8nM8x4cHNNHjMX0QNbsTFnQ==",
+          "requires": {
+            "@tds/shared-typography": "^1.3.5",
+            "@tds/util-helpers": "^1.5.1",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@tds/shared-styles": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@tds/shared-styles/-/shared-styles-2.0.1.tgz",
+          "integrity": "sha512-aVEzRu8sfJoIG7Rjooxb77oFWzUwL/cB6DcfarCqfbRRsBO+/9RUR8hGea7CQQ8dLf8dYWAphGm5stOf/D0J3Q==",
+          "requires": {
+            "@tds/core-colours": "^2.2.1",
+            "@tds/core-responsive": "^1.3.4",
+            "@tds/shared-typography": "^1.3.5"
+          }
+        },
+        "@tds/util-helpers": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/@tds/util-helpers/-/util-helpers-1.5.1.tgz",
+          "integrity": "sha512-D6ih5eGkh4eUQCJyjghV4O6bwVtBNpTcN7mv/tYgRUPSF3jiDJJ7gE1UZrvrtR3e6YXox62kmnEBE7iGD7NomA==",
+          "requires": {
+            "@tds/core-responsive": "^1.3.4"
+          }
+        }
+      }
+    },
     "@tds/core-link": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@tds/core-link/-/core-link-2.2.5.tgz",
@@ -3578,6 +3674,47 @@
         }
       }
     },
+    "@tds/core-standalone-icon": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@tds/core-standalone-icon/-/core-standalone-icon-2.1.18.tgz",
+      "integrity": "sha512-2QG8O44jRZgRD+PbZzfNOxfe2sE3R+5zeX0A6hy6zf0v0/tnZo1IGicWcyrp/txUJp+hXx9otPCvlR1WhJYp+w==",
+      "requires": {
+        "@tds/core-a11y-content": "^2.2.3",
+        "@tds/shared-styles": "^2.0.1",
+        "@tds/util-helpers": "^1.5.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@tds/core-responsive": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-responsive/-/core-responsive-1.3.4.tgz",
+          "integrity": "sha512-iGVxGxMcTXcBr9tMZ3/HQ/ytRoSUnoSZyE4w2mBNrkhNhPg7j7blJd2dnJYAFQe3era0YNbFOgf+CMmQHK2H3Q==",
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-media": "^1.10.0",
+            "sass-mq": "^5.0.0"
+          }
+        },
+        "@tds/shared-styles": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@tds/shared-styles/-/shared-styles-2.0.1.tgz",
+          "integrity": "sha512-aVEzRu8sfJoIG7Rjooxb77oFWzUwL/cB6DcfarCqfbRRsBO+/9RUR8hGea7CQQ8dLf8dYWAphGm5stOf/D0J3Q==",
+          "requires": {
+            "@tds/core-colours": "^2.2.1",
+            "@tds/core-responsive": "^1.3.4",
+            "@tds/shared-typography": "^1.3.5"
+          }
+        },
+        "@tds/util-helpers": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/@tds/util-helpers/-/util-helpers-1.5.1.tgz",
+          "integrity": "sha512-D6ih5eGkh4eUQCJyjghV4O6bwVtBNpTcN7mv/tYgRUPSF3jiDJJ7gE1UZrvrtR3e6YXox62kmnEBE7iGD7NomA==",
+          "requires": {
+            "@tds/core-responsive": "^1.3.4"
+          }
+        }
+      }
+    },
     "@tds/core-strong": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@tds/core-strong/-/core-strong-2.1.10.tgz",
@@ -3598,6 +3735,72 @@
         "@tds/shared-typography": "^1.3.5",
         "@tds/util-helpers": "^1.4.2",
         "prop-types": "^15.5.10"
+      }
+    },
+    "@tds/core-tooltip": {
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@tds/core-tooltip/-/core-tooltip-4.2.22.tgz",
+      "integrity": "sha512-xI2Mz48ZwoLj8W0rysnBy9QwMQdOXcG+n9JawlhFQZT797m5Uj5a80tsy51YbQo8cbs0OCHjinbFd2xErYTxww==",
+      "requires": {
+        "@tds/core-box": "^2.3.3",
+        "@tds/core-responsive": "^1.3.4",
+        "@tds/core-standalone-icon": "^2.1.18",
+        "@tds/core-text": "^3.1.4",
+        "@tds/shared-hocs": "^1.2.0",
+        "@tds/shared-styles": "^2.0.1",
+        "@tds/util-helpers": "^1.5.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@tds/core-box": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/@tds/core-box/-/core-box-2.3.3.tgz",
+          "integrity": "sha512-mDoeM0gRV8L6S2dWMw6sW8Kq+7dzq+JSRJRZ4BYxkiJWZVY55yaM7bEJzGgz4ZDTit4vscr53K1NfZV/e6MRCw==",
+          "requires": {
+            "@tds/core-responsive": "^1.3.4",
+            "@tds/util-helpers": "^1.5.1",
+            "@tds/util-prop-types": "^1.4.0",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@tds/core-responsive": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-responsive/-/core-responsive-1.3.4.tgz",
+          "integrity": "sha512-iGVxGxMcTXcBr9tMZ3/HQ/ytRoSUnoSZyE4w2mBNrkhNhPg7j7blJd2dnJYAFQe3era0YNbFOgf+CMmQHK2H3Q==",
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-media": "^1.10.0",
+            "sass-mq": "^5.0.0"
+          }
+        },
+        "@tds/core-text": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@tds/core-text/-/core-text-3.1.4.tgz",
+          "integrity": "sha512-/obC/u2d4+gafHCMoI4+NBu7q+fqHZmH+aNxaXOA42wm5QWE6LPegkV7f236yvK8nM8x4cHNNHjMX0QNbsTFnQ==",
+          "requires": {
+            "@tds/shared-typography": "^1.3.5",
+            "@tds/util-helpers": "^1.5.1",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@tds/shared-styles": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@tds/shared-styles/-/shared-styles-2.0.1.tgz",
+          "integrity": "sha512-aVEzRu8sfJoIG7Rjooxb77oFWzUwL/cB6DcfarCqfbRRsBO+/9RUR8hGea7CQQ8dLf8dYWAphGm5stOf/D0J3Q==",
+          "requires": {
+            "@tds/core-colours": "^2.2.1",
+            "@tds/core-responsive": "^1.3.4",
+            "@tds/shared-typography": "^1.3.5"
+          }
+        },
+        "@tds/util-helpers": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/@tds/util-helpers/-/util-helpers-1.5.1.tgz",
+          "integrity": "sha512-D6ih5eGkh4eUQCJyjghV4O6bwVtBNpTcN7mv/tYgRUPSF3jiDJJ7gE1UZrvrtR3e6YXox62kmnEBE7iGD7NomA==",
+          "requires": {
+            "@tds/core-responsive": "^1.3.4"
+          }
+        }
       }
     },
     "@tds/core-unordered-list": {
@@ -3649,11 +3852,19 @@
         }
       }
     },
+    "@tds/shared-animation": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tds/shared-animation/-/shared-animation-2.1.0.tgz",
+      "integrity": "sha512-gQcYIklFqADxDxSOyg7AFlo3TFQNKEXhLYE2az2bFzAlfpvhSkRGzHd0Vd+fjRSL0jY/Zp1INkAYgWLYWG1Wpg==",
+      "requires": {
+        "prop-types": "^15.5.10",
+        "react-transition-group": "^2.2.1"
+      }
+    },
     "@tds/shared-hocs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tds/shared-hocs/-/shared-hocs-1.2.0.tgz",
-      "integrity": "sha512-94X7yuwbFrzIRtQnRsuMNNmSk82HorYM6olcDINyPzjwkwUhn1MaUL4/zkUi/DBQOwSJCxMJM/uH+bOqhqHTdA==",
-      "dev": true
+      "integrity": "sha512-94X7yuwbFrzIRtQnRsuMNNmSk82HorYM6olcDINyPzjwkwUhn1MaUL4/zkUi/DBQOwSJCxMJM/uH+bOqhqHTdA=="
     },
     "@tds/shared-styles": {
       "version": "1.5.2",
@@ -4246,7 +4457,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
       "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
-      "dev": true,
       "requires": {
         "array.prototype.find": "^2.1.0",
         "function.prototype.name": "^1.1.1",
@@ -4579,6 +4789,11 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
+    "array-find-es6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/array-find-es6/-/array-find-es6-2.0.3.tgz",
+      "integrity": "sha512-35QZe7bM24H1Q+tAhFRVp6mUsCD+M1zREs45fjeiVqF2OAgzly76tcCjBISvu4AlR6slKv1oDaYr4KlPmzBKZA=="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -4644,7 +4859,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
       "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.13.0"
@@ -4654,7 +4868,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
       "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.15.0",
@@ -4670,8 +4883,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -5363,6 +5575,11 @@
         }
       }
     },
+    "brcast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -5793,6 +6010,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
     "character-entities": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
@@ -6119,6 +6341,11 @@
           "dev": true
         }
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "3.1.0",
@@ -6586,6 +6813,11 @@
       "requires": {
         "easy-table": "0.3.0"
       }
+    },
+    "consolidated-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -8869,6 +9101,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -8892,7 +9129,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -9144,6 +9380,11 @@
         "path-type": "^3.0.0"
       }
     },
+    "direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
+    },
     "discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -9184,11 +9425,18 @@
         "esutils": "^2.0.2"
       }
     },
+    "document.contains": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
+      "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "dom-helpers": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
@@ -9398,7 +9646,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -9527,7 +9774,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz",
       "integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.0.2"
@@ -9536,8 +9782,7 @@
         "object-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-          "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-          "dev": true
+          "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
         }
       }
     },
@@ -9578,7 +9823,6 @@
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
       "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -9596,7 +9840,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -10677,6 +10920,27 @@
         "bser": "^2.0.0"
       }
     },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -11650,8 +11914,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.name-polyfill": {
       "version": "1.0.6",
@@ -11663,7 +11926,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
       "integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1",
@@ -11680,8 +11942,7 @@
     "functions-have-names": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
-      "dev": true
+      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -12396,6 +12657,15 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
+    "global-cache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+      "integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "is-symbol": "^1.0.1"
+      }
+    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -12561,7 +12831,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -12584,8 +12853,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -12673,6 +12941,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {
@@ -13003,7 +13279,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -13550,8 +13825,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -13599,8 +13873,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -13810,7 +14083,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -13845,8 +14117,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.4",
@@ -13879,7 +14150,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -13892,6 +14162,11 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-touch-device": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+      "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -13969,6 +14244,26 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -15889,8 +16184,7 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -16996,8 +17290,7 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moo": {
       "version": "0.4.3",
@@ -18000,20 +18293,17 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-      "dev": true
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -18028,7 +18318,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -18040,7 +18329,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -18083,7 +18371,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -18807,8 +19094,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -20645,6 +20931,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -20700,7 +20994,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
       "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object.assign": "^4.1.0",
@@ -20905,7 +21198,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -20991,6 +21283,28 @@
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-5.1.0.tgz",
       "integrity": "sha512-Cksbgbviuf2mJfMyrKmcu7ycK6zX/ukuQO8dvRZdFWqATf5joalhjFc6etnBdGCcPA2LbhIwz+OPnQxLN/j1Fw==",
       "dev": true
+    },
+    "react-dates": {
+      "version": "21.8.0",
+      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
+      "integrity": "sha512-PPriGqi30CtzZmoHiGdhlA++YPYPYGCZrhydYmXXQ6RAvAsaONcPtYgXRTLozIOrsQ5mSo40+DiA5eOFHnZ6xw==",
+      "requires": {
+        "airbnb-prop-types": "^2.15.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "enzyme-shallow-equal": "^1.0.0",
+        "is-touch-device": "^1.0.1",
+        "lodash": "^4.1.1",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "raf": "^3.4.1",
+        "react-moment-proptypes": "^1.6.0",
+        "react-outside-click-handler": "^1.2.4",
+        "react-portal": "^4.2.0",
+        "react-with-direction": "^1.3.1",
+        "react-with-styles": "^4.1.0",
+        "react-with-styles-interface-css": "^6.0.0"
+      }
     },
     "react-dev-utils": {
       "version": "6.1.1",
@@ -21399,8 +21713,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-media": {
       "version": "1.10.0",
@@ -21411,6 +21724,34 @@
         "invariant": "^2.2.2",
         "json2mq": "^0.2.0",
         "prop-types": "^15.5.10"
+      }
+    },
+    "react-moment-proptypes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
+      "integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
+      "requires": {
+        "moment": ">=1.6.0"
+      }
+    },
+    "react-outside-click-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
+      "requires": {
+        "airbnb-prop-types": "^2.15.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "document.contains": "^1.0.1",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-portal": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+      "requires": {
+        "prop-types": "^15.5.8"
       }
     },
     "react-styleguidist": {
@@ -21585,6 +21926,15 @@
         }
       }
     },
+    "react-tabs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.1.tgz",
+      "integrity": "sha512-HpySC29NN1BkzBAnOC+ajfzPbTaVZcSWzMSjk56uAhPC/rBGtli8lTysR4CfPAyEE/hfweIzagOIoJ7nu80yng==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.12.0.tgz",
@@ -21601,12 +21951,47 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
       "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
       "requires": {
         "dom-helpers": "^3.4.0",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-with-direction": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+      "integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
+      "requires": {
+        "airbnb-prop-types": "^2.10.0",
+        "brcast": "^2.0.2",
+        "deepmerge": "^1.5.2",
+        "direction": "^1.0.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-with-styles": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.1.0.tgz",
+      "integrity": "sha512-zp05fyA6XFetqr07ox/a0bCFyEj//gUozI9cC1GW59zaGJ38STnxYvzotutgpzMyHOd7TFW9ZiZeBKjsYaS+RQ==",
+      "requires": {
+        "airbnb-prop-types": "^2.14.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "object.assign": "^4.1.0",
+        "prop-types": "^15.7.2",
+        "react-with-direction": "^1.3.1"
+      }
+    },
+    "react-with-styles-interface-css": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-6.0.0.tgz",
+      "integrity": "sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==",
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "global-cache": "^1.2.1"
       }
     },
     "read": {
@@ -21764,6 +22149,26 @@
         }
       }
     },
+    "recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -21786,8 +22191,7 @@
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
-      "dev": true
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -23151,8 +23555,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -23587,8 +23990,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -24223,8 +24625,7 @@
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-      "dev": true
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "2.0.0",
@@ -24290,7 +24691,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -24300,7 +24700,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -24886,8 +25285,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -25470,6 +25868,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+    },
     "uglify-js": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
@@ -25966,8 +26369,7 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "dev": true
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -26855,6 +27257,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@tds/core-chevron-link": "^2.1.16",
     "@tds/core-colours": "^2.2.1",
     "@tds/core-css-reset": "^2.0.5",
+    "@tds/core-dimple-divider": "^2.0.16",
     "@tds/core-flex-grid": "^4.0.1",
     "@tds/core-hairline-divider": "^2.0.13",
     "@tds/core-heading": "^3.0.4",

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -6,14 +6,7 @@ import FlexGrid from '@tds/core-flex-grid'
 import { safeRest } from '@tds/util-helpers'
 import { ChevronRight, ChevronLeft } from '@tds/core-interactive-icon'
 import { Tab, Tabs as ReactTabs, TabList, TabPanel } from 'react-tabs'
-import {
-  TabsContainer,
-  TabListContainer,
-  TabLabel,
-  TabArrows,
-  ArrowInner,
-  SandwichFilling,
-} from './styles'
+import { TabsContainer, TabListContainer, TabLabel, TabArrows, ArrowInner } from './styles'
 import hash from './hash'
 import Panel from './Panel/Panel'
 /**
@@ -35,7 +28,6 @@ const FlexContainer = p => (
 const Divider = () => (
   <>
     <HairlineDivider />
-    <SandwichFilling />
     <DimpleDivider />
   </>
 )
@@ -199,7 +191,7 @@ const Tabs = props => {
     const newTab = props.children[index]
     const previousTab = props.children[previousIndex]
 
-    return props.onOpen(newTab.props.id, previousTab.props.id, event)
+    return props.onOpen(newTab.props.id, previousTab.props ? previousTab.props.id : null, event)
   }
 
   return (
@@ -239,7 +231,7 @@ const Tabs = props => {
         {stretch ? (
           <Divider />
         ) : (
-          <FlexContainer>
+          <FlexContainer gutter={false}>
             <Divider />
           </FlexContainer>
         )}

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -58,13 +58,15 @@ const Tabs = props => {
   const [resizeTriggered, setResizeTriggered] = useState(false)
   const [isLeftArrowVisible, setLeftArrowVisible] = useState(false)
   const [isRightArrowVisible, setRightArrowVisible] = useState(false)
-  const [current, setCurrent] = useState(props.selectedIndex || 0)
+  const [current, setCurrent] = useState(0)
   const { children, stretch, leftArrowLabel, rightArrowLabel, ...rest } = props
 
   useEffect(() => {
-    if (props.selectedIndex === undefined || props.selectedIndex === null) return
-    setCurrent(props.selectedIndex)
-  }, [props.selectedIndex])
+    if (props.open === null || props.open === undefined) return
+    if (!props.children.length) return
+    const tabIndex = props.children.findIndex(child => child.props.id === props.open)
+    setCurrent(tabIndex)
+  }, [props.open])
 
   const getTabsWidth = () => {
     let tabsWidthValue = 0
@@ -158,6 +160,7 @@ const Tabs = props => {
       return props.children.map((tab, i) => {
         return (
           <Tab
+            id={tab.props.id}
             key={hash(i)}
             onKeyUp={e => handleTabsKeyUp(e, i)}
             onClick={() => setCurrent(i)}
@@ -192,9 +195,16 @@ const Tabs = props => {
     }
   }, [])
 
+  const handleSelect = (index, previousIndex, event) => {
+    const newTab = props.children[index]
+    const previousTab = props.children[previousIndex]
+
+    return props.onOpen(newTab.props.id, previousTab.props.id, event)
+  }
+
   return (
     <TabsContainer {...safeRest(rest)} ref={tabsRoot}>
-      <ReactTabs selectedIndex={current} onSelect={props.onSelect}>
+      <ReactTabs selectedIndex={current} onSelect={handleSelect}>
         <FlexContainer gutter={false}>
           {isLeftArrowVisible && (
             <TabArrows
@@ -249,11 +259,11 @@ Tabs.propTypes = {
   /**
    * Event raised on tab click
    */
-  onSelect: PropTypes.func,
+  onOpen: PropTypes.func,
   /**
-   * Set the selected tab by index
+   * Set the selected tab by id
    */
-  selectedIndex: PropTypes.number,
+  open: PropTypes.string,
   /**
    * Dividers stretch full width of container if true, default=false
    */
@@ -261,10 +271,10 @@ Tabs.propTypes = {
 }
 
 Tabs.defaultProps = {
-  selectedIndex: 0,
+  open: null,
   leftArrowLabel: 'Move menu to the left',
   rightArrowLabel: 'Move menu to the right',
-  onSelect: () => {},
+  onOpen: () => {},
   stretch: false,
 }
 

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -6,7 +6,14 @@ import FlexGrid from '@tds/core-flex-grid'
 import { safeRest } from '@tds/util-helpers'
 import { ChevronRight, ChevronLeft } from '@tds/core-interactive-icon'
 import { Tab, Tabs as ReactTabs, TabList, TabPanel } from 'react-tabs'
-import { TabsContainer, TabListContainer, TabLabel, TabArrows, ArrowInner } from './styles'
+import {
+  TabsContainer,
+  TabListContainer,
+  TabLabel,
+  TabArrows,
+  ArrowInner,
+  SandwichFilling,
+} from './styles'
 import hash from './hash'
 import Panel from './Panel/Panel'
 /**
@@ -14,6 +21,7 @@ import Panel from './Panel/Panel'
  * @visibleName Tabs (beta)
  */
 
+// no need for props validation, internal use only
 const FlexContainer = p => (
   <FlexGrid gutter={p.gutter}>
     <FlexGrid.Row>
@@ -27,7 +35,7 @@ const FlexContainer = p => (
 const Divider = () => (
   <>
     <HairlineDivider />
-    <div style={{ height: '5px' }} />
+    <SandwichFilling />
     <DimpleDivider />
   </>
 )

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -37,8 +37,13 @@ const Tabs = props => {
   const [resizeTriggered, setResizeTriggered] = useState(false)
   const [isLeftArrowVisible, setLeftArrowVisible] = useState(false)
   const [isRightArrowVisible, setRightArrowVisible] = useState(false)
-  const [current, setCurrent] = useState(0)
+  const [current, setCurrent] = useState(props.selectedIndex || 0)
   const { children, leftArrowLabel, rightArrowLabel, ...rest } = props
+
+  useEffect(() => {
+    if (props.selectedIndex === undefined || props.selectedIndex === null) return
+    setCurrent(props.selectedIndex)
+  }, [props.selectedIndex])
 
   const getTabsWidth = () => {
     let tabsWidthValue = 0
@@ -185,9 +190,10 @@ const Tabs = props => {
                 <ArrowInner direction="left">
                   <ChevronLeft variant="basic" />
                 </ArrowInner>
+                s
               </TabArrows>
             )}
-            <ReactTabs>
+            <ReactTabs selectedIndex={current} onSelect={props.onSelect}>
               <TabBorder>
                 <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
                   <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
@@ -222,11 +228,21 @@ Tabs.propTypes = {
   children: PropTypes.node.isRequired,
   leftArrowLabel: PropTypes.string,
   rightArrowLabel: PropTypes.string,
+  /**
+   * Event raised on tab click
+   */
+  onSelect: PropTypes.func,
+  /**
+   * Set the selected tab by index
+   */
+  selectedIndex: PropTypes.number,
 }
 
 Tabs.defaultProps = {
+  selectedIndex: 0,
   leftArrowLabel: 'Move menu to the left',
   rightArrowLabel: 'Move menu to the right',
+  onSelect: () => {},
 }
 
 Tabs.Panel = Panel

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -1,23 +1,36 @@
 import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import HairlineDivider from '@tds/core-hairline-divider'
+import DimpleDivider from '@tds/core-dimple-divider'
 import FlexGrid from '@tds/core-flex-grid'
 import { safeRest } from '@tds/util-helpers'
 import { ChevronRight, ChevronLeft } from '@tds/core-interactive-icon'
 import { Tab, Tabs as ReactTabs, TabList, TabPanel } from 'react-tabs'
-import {
-  TabsContainer,
-  TabBorder,
-  TabListContainer,
-  TabLabel,
-  TabArrows,
-  ArrowInner,
-} from './styles'
+import { TabsContainer, TabListContainer, TabLabel, TabArrows, ArrowInner } from './styles'
 import hash from './hash'
 import Panel from './Panel/Panel'
 /**
  * @version ./package.json
  * @visibleName Tabs (beta)
  */
+
+const FlexContainer = p => (
+  <FlexGrid gutter={p.gutter}>
+    <FlexGrid.Row>
+      <FlexGrid.Col xs={12} tabIndex={p.tabIndex}>
+        {p.children}
+      </FlexGrid.Col>
+    </FlexGrid.Row>
+  </FlexGrid>
+)
+
+const Divider = () => (
+  <>
+    <HairlineDivider />
+    <div style={{ height: '5px' }} />
+    <DimpleDivider />
+  </>
+)
 
 const Tabs = props => {
   // Constants
@@ -38,7 +51,7 @@ const Tabs = props => {
   const [isLeftArrowVisible, setLeftArrowVisible] = useState(false)
   const [isRightArrowVisible, setRightArrowVisible] = useState(false)
   const [current, setCurrent] = useState(props.selectedIndex || 0)
-  const { children, leftArrowLabel, rightArrowLabel, ...rest } = props
+  const { children, stretch, leftArrowLabel, rightArrowLabel, ...rest } = props
 
   useEffect(() => {
     if (props.selectedIndex === undefined || props.selectedIndex === null) return
@@ -155,13 +168,9 @@ const Tabs = props => {
       return props.children.map((tab, i) => {
         return (
           <TabPanel key={hash(i)}>
-            <FlexGrid>
-              <FlexGrid.Row>
-                <FlexGrid.Col xs={12} tabindex="0">
-                  <Panel {...rest}>{children[current]}</Panel>
-                </FlexGrid.Col>
-              </FlexGrid.Row>
-            </FlexGrid>
+            <FlexContainer tabIndex="0">
+              <Panel {...rest}>{children[current]}</Panel>
+            </FlexContainer>
           </TabPanel>
         )
       })
@@ -174,49 +183,50 @@ const Tabs = props => {
       setTimeout(() => getTabsWidth(), 100)
     }
   }, [])
+
   return (
     <TabsContainer {...safeRest(rest)} ref={tabsRoot}>
-      <FlexGrid gutter={false}>
-        <FlexGrid.Row>
-          <FlexGrid.Col xs={12}>
-            {isLeftArrowVisible && (
-              <TabArrows
-                tabIndex="0"
-                direction="left"
-                aria-label={leftArrowLabel}
-                onKeyUp={e => handleArrowKeyUp(e, 'left')}
-                onClick={() => scrollTabs('left')}
-              >
-                <ArrowInner direction="left">
-                  <ChevronLeft variant="basic" />
-                </ArrowInner>
-                s
-              </TabArrows>
-            )}
-            <ReactTabs selectedIndex={current} onSelect={props.onSelect}>
-              <TabBorder>
-                <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
-                  <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
-                </TabListContainer>
-              </TabBorder>
-              {mapTabContent()}
-            </ReactTabs>
-            {isRightArrowVisible && (
-              <TabArrows
-                tabIndex="0"
-                direction="right"
-                onKeyUp={e => handleArrowKeyUp(e, 'right')}
-                aria-label={rightArrowLabel}
-                onClick={() => scrollTabs('right')}
-              >
-                <ArrowInner direction="right">
-                  <ChevronRight variant="basic" />
-                </ArrowInner>
-              </TabArrows>
-            )}
-          </FlexGrid.Col>
-        </FlexGrid.Row>
-      </FlexGrid>
+      <ReactTabs selectedIndex={current} onSelect={props.onSelect}>
+        <FlexContainer gutter={false}>
+          {isLeftArrowVisible && (
+            <TabArrows
+              tabIndex="0"
+              direction="left"
+              aria-label={leftArrowLabel}
+              onKeyUp={e => handleArrowKeyUp(e, 'left')}
+              onClick={() => scrollTabs('left')}
+            >
+              <ArrowInner direction="left">
+                <ChevronLeft variant="basic" />
+              </ArrowInner>
+            </TabArrows>
+          )}
+          <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
+            <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
+          </TabListContainer>
+          {isRightArrowVisible && (
+            <TabArrows
+              tabIndex="0"
+              direction="right"
+              onKeyUp={e => handleArrowKeyUp(e, 'right')}
+              aria-label={rightArrowLabel}
+              onClick={() => scrollTabs('right')}
+            >
+              <ArrowInner direction="right">
+                <ChevronRight variant="basic" />
+              </ArrowInner>
+            </TabArrows>
+          )}
+        </FlexContainer>
+        {stretch ? (
+          <Divider />
+        ) : (
+          <FlexContainer>
+            <Divider />
+          </FlexContainer>
+        )}
+        {mapTabContent()}
+      </ReactTabs>
     </TabsContainer>
   )
 }
@@ -236,6 +246,10 @@ Tabs.propTypes = {
    * Set the selected tab by index
    */
   selectedIndex: PropTypes.number,
+  /**
+   * Dividers stretch full width of container if true, default=false
+   */
+  stretch: PropTypes.bool,
 }
 
 Tabs.defaultProps = {
@@ -243,6 +257,7 @@ Tabs.defaultProps = {
   leftArrowLabel: 'Move menu to the left',
   rightArrowLabel: 'Move menu to the right',
   onSelect: () => {},
+  stretch: false,
 }
 
 Tabs.Panel = Panel

--- a/packages/Tabs/Tabs.md
+++ b/packages/Tabs/Tabs.md
@@ -35,19 +35,22 @@ Note that the `copy` prop must be provided at all times for the correct accessib
 ### Controlled Example
 
 Use `selectedIndex` and `onSelect` to control the component externally
+Stretch will make the dividers fit the width of the containing node
 
 ```jsx
 <Tabs
   copy="en"
   selectedIndex={1}
-  onSelect={(i, p, e) => {
-    console.log('tab clicked', i, 'previous', p, 'event', e)
+  onSelect={(index, previous, event) => {
+    console.log('tab clicked', index, 'previous', previous, 'event', event)
     return true // return false to cancel
   }}
+  stretch
 >
   <Tabs.Panel heading="Themepacks" />
   <Tabs.Panel heading="Premium" />
   <Tabs.Panel heading="A-la-carte" />
   <Tabs.Panel heading="Essentials" />
+  {/* here you might dynamically show content based on onSelect index */}
 </Tabs>
 ```

--- a/packages/Tabs/Tabs.md
+++ b/packages/Tabs/Tabs.md
@@ -31,3 +31,23 @@ Note that the `copy` prop must be provided at all times for the correct accessib
   </Tabs.Panel>
 </Tabs>
 ```
+
+### Controlled Example
+
+Use `selectedIndex` and `onSelect` to control the component externally
+
+```jsx
+<Tabs
+  copy="en"
+  selectedIndex={1}
+  onSelect={(i, p, e) => {
+    console.log('tab clicked', i, 'previous', p, 'event', e)
+    return true // return false to cancel
+  }}
+>
+  <Tabs.Panel heading="Themepacks" />
+  <Tabs.Panel heading="Premium" />
+  <Tabs.Panel heading="A-la-carte" />
+  <Tabs.Panel heading="Essentials" />
+</Tabs>
+```

--- a/packages/Tabs/Tabs.md
+++ b/packages/Tabs/Tabs.md
@@ -40,17 +40,23 @@ Stretch will make the dividers fit the width of the containing node
 ```jsx
 <Tabs
   copy="en"
-  selectedIndex={1}
-  onSelect={(index, previous, event) => {
-    console.log('tab clicked', index, 'previous', previous, 'event', event)
+  open="a-la-carte"
+  onOpen={(id, previousId, event) => {
+    console.log('tab clicked:', id, 'previous tab:', previousId, 'event:', event)
     return true // return false to cancel
   }}
   stretch
 >
-  <Tabs.Panel heading="Themepacks" />
-  <Tabs.Panel heading="Premium" />
-  <Tabs.Panel heading="A-la-carte" />
-  <Tabs.Panel heading="Essentials" />
+  <Tabs.Panel id="themepacks" heading="Themepacks" />
+  <Tabs.Panel id="premium" heading="Premium" />
+  <Tabs.Panel id="a-la-carte" heading="A-la-carte" />
+  <Tabs.Panel id="essentials" heading="Essentials" />
   {/* here you might dynamically show content based on onSelect index */}
 </Tabs>
 ```
+
+### Accessibility
+
+- When using Tabs, the consuming application should allow hashes in the url to automatically load a tab. Eg. `https://t.com#premium` should load the Premium tab.
+
+- The application should also change the page url to include the hash as tabs change

--- a/packages/Tabs/__tests__/Tabs.spec.jsx
+++ b/packages/Tabs/__tests__/Tabs.spec.jsx
@@ -4,29 +4,48 @@ import { mount } from 'enzyme'
 import Tabs from '../Tabs'
 
 describe('Tabs', () => {
-  const children = (
-    <Tabs copy="en">
-      <Tabs.Panel>Content 1</Tabs.Panel>
-      <Tabs.Panel>Content 2</Tabs.Panel>
-      <Tabs.Panel>Content 3</Tabs.Panel>
-    </Tabs>
-  )
-  const doMount = () => mount(children)
+  const doMount = (props = {}) =>
+    mount(
+      <Tabs copy="en" {...props}>
+        <Tabs.Panel>Content 1</Tabs.Panel>
+        <Tabs.Panel>Content 2</Tabs.Panel>
+        <Tabs.Panel>Content 3</Tabs.Panel>
+      </Tabs>
+    )
 
   it('renders', () => {
     const tabs = doMount()
     expect(tabs).toMatchSnapshot()
+    expect(tabs.text()).toContain('Content 1')
   })
   it('does other things', () => {
     const tabs = doMount()
     expect(tabs).toExist()
   })
-  it('does not allow custom CSS', () => {
-    const tabs = doMount({
-      className: 'my-custom-class',
-      style: { color: 'hotpink' },
-    })
-    expect(tabs).not.toHaveProp('className', 'my-custom-class')
-    expect(tabs).not.toHaveProp('style')
+
+  it('selects a tab', () => {
+    const tabs = doMount({ selectedIndex: 1 })
+    expect(tabs).toHaveProp('selectedIndex', 1)
+    expect(tabs.text()).toContain('Content 2')
+    expect(tabs.text()).not.toContain('Content 1')
+  })
+
+  it('raises an event when tab clicked', () => {
+    const onSelect = jest.fn()
+    const tabs = doMount({ onSelect })
+    tabs
+      .find('Tab')
+      .at(2)
+      .simulate('click')
+    expect(tabs.text()).toContain('Content 3')
+  })
+
+  it('stretches', () => {
+    const tabs = doMount()
+    expect(tabs.find('FlexContainer').length).toBe(3)
+
+    const tabs1 = doMount({ stretch: true })
+    expect(tabs1).toHaveProp('stretch', true)
+    expect(tabs1.find('FlexContainer').length).toBe(2)
   })
 })

--- a/packages/Tabs/__tests__/Tabs.spec.jsx
+++ b/packages/Tabs/__tests__/Tabs.spec.jsx
@@ -7,9 +7,9 @@ describe('Tabs', () => {
   const doMount = (props = {}) =>
     mount(
       <Tabs copy="en" {...props}>
-        <Tabs.Panel>Content 1</Tabs.Panel>
-        <Tabs.Panel>Content 2</Tabs.Panel>
-        <Tabs.Panel>Content 3</Tabs.Panel>
+        <Tabs.Panel id="1">Content 1</Tabs.Panel>
+        <Tabs.Panel id="2">Content 2</Tabs.Panel>
+        <Tabs.Panel id="3">Content 3</Tabs.Panel>
       </Tabs>
     )
 
@@ -24,20 +24,29 @@ describe('Tabs', () => {
   })
 
   it('selects a tab', () => {
-    const tabs = doMount({ selectedIndex: 1 })
-    expect(tabs).toHaveProp('selectedIndex', 1)
+    const tabs = doMount({ open: '2' })
+    expect(tabs).toHaveProp('open', '2')
     expect(tabs.text()).toContain('Content 2')
     expect(tabs.text()).not.toContain('Content 1')
   })
 
   it('raises an event when tab clicked', () => {
-    const onSelect = jest.fn()
-    const tabs = doMount({ onSelect })
+    const onOpen = jest.fn()
+    const tabs = doMount({ onOpen })
     tabs
       .find('Tab')
       .at(2)
       .simulate('click')
     expect(tabs.text()).toContain('Content 3')
+    expect(onOpen).toHaveBeenCalledWith('3', '1', expect.any(Object))
+
+    tabs
+      .find('Tab')
+      .at(1)
+      .simulate('click')
+
+    expect(tabs.text()).toContain('Content 2')
+    expect(onOpen).toHaveBeenCalledWith('2', '3', expect.any(Object))
   })
 
   it('stretches', () => {

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs renders 1`] = `
-.c7 {
+.c6 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -16,7 +16,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c9 {
+.c7 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -36,7 +36,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -148,10 +148,6 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c8 {
-  height: 5px;
-}
-
 .c5 {
   height: 100%;
   display: block;
@@ -195,35 +191,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
@@ -352,7 +348,7 @@ exports[`Tabs renders 1`] = `
       }
       forwardedRef={
         Object {
-          "current": .c7 {
+          "current": .c6 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -367,7 +363,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c9 {
+.c7 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -387,7 +383,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -499,10 +495,6 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c8 {
-  height: 5px;
-}
-
 .c5 {
   height: 100%;
   display: block;
@@ -546,35 +538,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c6 {
+  .c8 {
     display: block;
     text-align: inherit;
   }
@@ -736,16 +728,13 @@ exports[`Tabs renders 1`] = `
                   class="c2"
                 >
                   <div
-                    class="c6"
+                    class="c3"
                   >
                     <hr
-                      class="c7"
-                    />
-                    <div
-                      class="c8"
+                      class="c6"
                     />
                     <hr
-                      class="c9"
+                      class="c7"
                     />
                   </div>
                 </div>
@@ -763,7 +752,7 @@ exports[`Tabs renders 1`] = `
                     class="c2"
                   >
                     <div
-                      class="c6"
+                      class="c8"
                       tabindex="0"
                     >
                       <div
@@ -969,7 +958,7 @@ exports[`Tabs renders 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                             "isStatic": false,
-                                            "lastClassName": "c6",
+                                            "lastClassName": "c8",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -1144,7 +1133,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-3",
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1154,7 +1143,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1201,7 +1190,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-3",
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1211,7 +1200,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1258,7 +1247,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-3",
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1268,7 +1257,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1303,10 +1292,11 @@ exports[`Tabs renders 1`] = `
                 </FlexGrid>
               </FlexContainer>
               <FlexContainer
+                gutter={false}
                 key=".1"
               >
                 <FlexGrid
-                  gutter={true}
+                  gutter={false}
                   limitWidth={true}
                   outsideGutter={true}
                 >
@@ -1418,7 +1408,7 @@ exports[`Tabs renders 1`] = `
                                   xs={12}
                                 >
                                   <Col__StyledCol
-                                    gutter={true}
+                                    gutter={false}
                                     hiddenLevel={
                                       Array [
                                         12,
@@ -1447,7 +1437,7 @@ exports[`Tabs renders 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                             "isStatic": false,
-                                            "lastClassName": "c6",
+                                            "lastClassName": "c8",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -1465,7 +1455,7 @@ exports[`Tabs renders 1`] = `
                                         }
                                       }
                                       forwardedRef={null}
-                                      gutter={true}
+                                      gutter={false}
                                       hiddenLevel={
                                         Array [
                                           12,
@@ -1487,7 +1477,7 @@ exports[`Tabs renders 1`] = `
                                       xs={12}
                                     >
                                       <div
-                                        className="c6"
+                                        className="c3"
                                       >
                                         <Divider
                                           key=".0"
@@ -1508,7 +1498,7 @@ exports[`Tabs renders 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "HairlineDivider__StyledHairlineDivider-biamlk-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "c7",
+                                                      "lastClassName": "c6",
                                                       "rules": Array [
                                                         "padding: 0;",
                                                         "margin: 0;",
@@ -1531,42 +1521,11 @@ exports[`Tabs renders 1`] = `
                                                 vertical={false}
                                               >
                                                 <hr
-                                                  className="c7"
+                                                  className="c6"
                                                 />
                                               </StyledComponent>
                                             </HairlineDivider__StyledHairlineDivider>
                                           </HairlineDivider>
-                                          <styles__SandwichFilling>
-                                            <StyledComponent
-                                              forwardedComponent={
-                                                Object {
-                                                  "$$typeof": Symbol(react.forward_ref),
-                                                  "attrs": Array [],
-                                                  "componentStyle": ComponentStyle {
-                                                    "componentId": "styles__SandwichFilling-fcx45d-2",
-                                                    "isStatic": false,
-                                                    "lastClassName": "c8",
-                                                    "rules": Array [
-                                                      "height:5px;",
-                                                    ],
-                                                  },
-                                                  "displayName": "styles__SandwichFilling",
-                                                  "foldedComponentIds": Array [],
-                                                  "render": [Function],
-                                                  "styledComponentId": "styles__SandwichFilling-fcx45d-2",
-                                                  "target": "div",
-                                                  "toString": [Function],
-                                                  "warnTooManyClasses": [Function],
-                                                  "withComponent": [Function],
-                                                }
-                                              }
-                                              forwardedRef={null}
-                                            >
-                                              <div
-                                                className="c8"
-                                              />
-                                            </StyledComponent>
-                                          </styles__SandwichFilling>
                                           <DimpleDivider>
                                             <DimpleDivider__StyledDimpleDivider>
                                               <StyledComponent
@@ -1577,7 +1536,7 @@ exports[`Tabs renders 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "c9",
+                                                      "lastClassName": "c7",
                                                       "rules": Array [
                                                         "padding: 0;",
                                                         "margin: 0;",
@@ -1599,7 +1558,7 @@ exports[`Tabs renders 1`] = `
                                                 forwardedRef={null}
                                               >
                                                 <hr
-                                                  className="c9"
+                                                  className="c7"
                                                 />
                                               </StyledComponent>
                                             </DimpleDivider__StyledDimpleDivider>
@@ -1780,7 +1739,7 @@ exports[`Tabs renders 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                                 "isStatic": false,
-                                                "lastClassName": "c6",
+                                                "lastClassName": "c8",
                                                 "rules": Array [
                                                   [Function],
                                                   [Function],
@@ -1821,7 +1780,7 @@ exports[`Tabs renders 1`] = `
                                           xs={12}
                                         >
                                           <div
-                                            className="c6"
+                                            className="c8"
                                             tabIndex="0"
                                           >
                                             <Panel

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -1,6 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs renders 1`] = `
+.c7 {
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  -webkit-transform: rotate(-0.00001deg);
+  -ms-transform: rotate(-0.00001deg);
+  transform: rotate(-0.00001deg);
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+  height: 1px;
+  background-color: #d8d8d8;
+}
+
+.c8 {
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  height: 32px;
+  background-image: radial-gradient(ellipse at top,rgba(150,150,150,0.1) 0%,rgba(0,0,0,0) 70%);
+}
+
 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -13,7 +36,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c7 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -112,29 +135,9 @@ exports[`Tabs renders 1`] = `
 
 .c0 .react-tabs__tab-panel.react-tabs__tab-panel--selected {
   display: block;
-  margin-top: 24px;
 }
 
 .c4 {
-  border-bottom: 1px solid #d8d8d8;
-  overflow-x: hidden;
-  margin-bottom: 8px;
-}
-
-.c4:after {
-  content: '';
-  position: absolute;
-  top: 52px;
-  left: 0;
-  width: 100%;
-  height: 32px;
-  background-image: radial-gradient( at center top,rgba(150,150,150,0.1) 0%,rgba(0,0,0,0) 70% );
-  padding: 0px;
-  margin: 0px;
-  border-width: 0px;
-}
-
-.c5 {
   position: relative;
   -webkit-transition: 0.9s all ease;
   transition: 0.9s all ease;
@@ -145,7 +148,7 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c6 {
+.c5 {
   height: 100%;
   display: block;
   padding-bottom: 8px;
@@ -188,35 +191,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
@@ -312,6 +315,7 @@ exports[`Tabs renders 1`] = `
   onSelect={[Function]}
   rightArrowLabel="Move menu to the right"
   selectedIndex={0}
+  stretch={false}
 >
   <styles__TabsContainer
     copy="en"
@@ -329,7 +333,7 @@ exports[`Tabs renders 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:1px 0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 0;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{box-shadow:0 0 0 2px #979797;border-radius:4px;outline:none;h4{border-bottom:none;}}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:24px;}}",
+              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:1px 0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 0;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{box-shadow:0 0 0 2px #979797;border-radius:4px;outline:none;h4{border-bottom:none;}}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;}}",
             ],
           },
           "displayName": "styles__TabsContainer",
@@ -344,7 +348,30 @@ exports[`Tabs renders 1`] = `
       }
       forwardedRef={
         Object {
-          "current": .c3 {
+          "current": .c7 {
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  -webkit-transform: rotate(-0.00001deg);
+  -ms-transform: rotate(-0.00001deg);
+  transform: rotate(-0.00001deg);
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+  height: 1px;
+  background-color: #d8d8d8;
+}
+
+.c8 {
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  height: 32px;
+  background-image: radial-gradient(ellipse at top,rgba(150,150,150,0.1) 0%,rgba(0,0,0,0) 70%);
+}
+
+.c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -356,7 +383,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c7 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -455,29 +482,9 @@ exports[`Tabs renders 1`] = `
 
 .c0 .react-tabs__tab-panel.react-tabs__tab-panel--selected {
   display: block;
-  margin-top: 24px;
 }
 
 .c4 {
-  border-bottom: 1px solid #d8d8d8;
-  overflow-x: hidden;
-  margin-bottom: 8px;
-}
-
-.c4:after {
-  content: '';
-  position: absolute;
-  top: 52px;
-  left: 0;
-  width: 100%;
-  height: 32px;
-  background-image: radial-gradient( at center top,rgba(150,150,150,0.1) 0%,rgba(0,0,0,0) 70% );
-  padding: 0px;
-  margin: 0px;
-  border-width: 0px;
-}
-
-.c5 {
   position: relative;
   -webkit-transition: 0.9s all ease;
   transition: 0.9s all ease;
@@ -488,7 +495,7 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c6 {
+.c5 {
   height: 100%;
   display: block;
   padding-bottom: 8px;
@@ -531,35 +538,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c7 {
+  .c6 {
     display: block;
     text-align: inherit;
   }
@@ -653,110 +660,128 @@ exports[`Tabs renders 1`] = `
             class="c0"
           >
             <div
-              class="c1"
+              class="react-tabs"
+              data-tabs="true"
             >
               <div
-                class="c2"
+                class="c1"
               >
                 <div
-                  class="c3"
+                  class="c2"
                 >
                   <div
-                    class="react-tabs"
-                    data-tabs="true"
+                    class="c3"
                   >
                     <div
                       class="c4"
                     >
-                      <div
-                        class="c5"
+                      <ul
+                        class="react-tabs__tab-list"
+                        role="tablist"
                       >
-                        <ul
-                          class="react-tabs__tab-list"
-                          role="tablist"
+                        <li
+                          aria-controls="react-tabs-1"
+                          aria-disabled="false"
+                          aria-selected="true"
+                          class="react-tabs__tab react-tabs__tab--selected"
+                          id="react-tabs-0"
+                          role="tab"
+                          tabindex="0"
                         >
-                          <li
-                            aria-controls="react-tabs-1"
-                            aria-disabled="false"
-                            aria-selected="true"
-                            class="react-tabs__tab react-tabs__tab--selected"
-                            id="react-tabs-0"
-                            role="tab"
-                            tabindex="0"
-                          >
-                            <h4
-                              class="c6"
-                            />
-                          </li>
-                          <li
-                            aria-controls="react-tabs-3"
-                            aria-disabled="false"
-                            aria-selected="false"
-                            class="react-tabs__tab"
-                            id="react-tabs-2"
-                            role="tab"
-                          >
-                            <h4
-                              class="c6"
-                            />
-                          </li>
-                          <li
-                            aria-controls="react-tabs-5"
-                            aria-disabled="false"
-                            aria-selected="false"
-                            class="react-tabs__tab"
-                            id="react-tabs-4"
-                            role="tab"
-                          >
-                            <h4
-                              class="c6"
-                            />
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                    <div
-                      aria-labelledby="react-tabs-0"
-                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
-                      id="react-tabs-1"
-                      role="tabpanel"
-                    >
-                      <div
-                        class="c1"
-                      >
-                        <div
-                          class="c2"
+                          <h4
+                            class="c5"
+                          />
+                        </li>
+                        <li
+                          aria-controls="react-tabs-3"
+                          aria-disabled="false"
+                          aria-selected="false"
+                          class="react-tabs__tab"
+                          id="react-tabs-2"
+                          role="tab"
                         >
-                          <div
-                            class="c7"
-                          >
-                            <div
-                              copy="en"
-                              selectedindex="0"
-                            >
-                              <div>
-                                Content 1
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                          <h4
+                            class="c5"
+                          />
+                        </li>
+                        <li
+                          aria-controls="react-tabs-5"
+                          aria-disabled="false"
+                          aria-selected="false"
+                          class="react-tabs__tab"
+                          id="react-tabs-4"
+                          role="tab"
+                        >
+                          <h4
+                            class="c5"
+                          />
+                        </li>
+                      </ul>
                     </div>
-                    <div
-                      aria-labelledby="react-tabs-2"
-                      class="react-tabs__tab-panel"
-                      id="react-tabs-3"
-                      role="tabpanel"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <hr
+                      class="c7"
                     />
                     <div
-                      aria-labelledby="react-tabs-4"
-                      class="react-tabs__tab-panel"
-                      id="react-tabs-5"
-                      role="tabpanel"
+                      style="height: 5px;"
+                    />
+                    <hr
+                      class="c8"
                     />
                   </div>
                 </div>
               </div>
+              <div
+                aria-labelledby="react-tabs-0"
+                class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                id="react-tabs-1"
+                role="tabpanel"
+              >
+                <div
+                  class="c1"
+                >
+                  <div
+                    class="c2"
+                  >
+                    <div
+                      class="c6"
+                      tabindex="0"
+                    >
+                      <div
+                        copy="en"
+                        selectedindex="0"
+                      >
+                        <div>
+                          Content 1
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-labelledby="react-tabs-2"
+                class="react-tabs__tab-panel"
+                id="react-tabs-3"
+                role="tabpanel"
+              />
+              <div
+                aria-labelledby="react-tabs-4"
+                class="react-tabs__tab-panel"
+                id="react-tabs-5"
+                role="tabpanel"
+              />
             </div>
           </div>,
         }
@@ -768,65 +793,38 @@ exports[`Tabs renders 1`] = `
         className="c0"
         onSelect={[Function]}
       >
-        <FlexGrid
-          gutter={false}
-          limitWidth={true}
-          outsideGutter={true}
+        <Tabs
+          defaultFocus={false}
+          defaultIndex={null}
+          forceRenderTabPanel={false}
+          onSelect={[Function]}
+          selectedIndex={0}
         >
-          <FlexGrid__StyledGrid
-            limitWidth={true}
-            outsideGutter={true}
-            reverseLevel={
-              Array [
-                false,
-                false,
-                false,
-                false,
-                false,
-              ]
-            }
+          <UncontrolledTabs
+            className="react-tabs"
+            focus={false}
+            forceRenderTabPanel={false}
+            onSelect={[Function]}
+            selectedIndex={0}
           >
-            <StyledComponent
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
-                    "isStatic": false,
-                    "lastClassName": "c1",
-                    "rules": Array [
-                      [Function],
-                    ],
-                  },
-                  "displayName": "FlexGrid__StyledGrid",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-              limitWidth={true}
-              outsideGutter={true}
-              reverseLevel={
-                Array [
-                  false,
-                  false,
-                  false,
-                  false,
-                  false,
-                ]
-              }
+            <div
+              className="react-tabs"
+              data-tabs={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
             >
-              <div
-                className="c1"
+              <FlexContainer
+                gutter={false}
+                key=".0"
               >
-                <Row>
-                  <Row__StyledRow
+                <FlexGrid
+                  gutter={false}
+                  limitWidth={true}
+                  outsideGutter={true}
+                >
+                  <FlexGrid__StyledGrid
+                    limitWidth={true}
+                    outsideGutter={true}
                     reverseLevel={
                       Array [
                         false,
@@ -843,20 +841,17 @@ exports[`Tabs renders 1`] = `
                           "$$typeof": Symbol(react.forward_ref),
                           "attrs": Array [],
                           "componentStyle": ComponentStyle {
-                            "componentId": "Row__StyledRow-sc-1goz0ht-0",
+                            "componentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
                             "isStatic": false,
-                            "lastClassName": "c2",
+                            "lastClassName": "c1",
                             "rules": Array [
-                              [Function],
-                              [Function],
-                              [Function],
                               [Function],
                             ],
                           },
-                          "displayName": "Row__StyledRow",
+                          "displayName": "FlexGrid__StyledGrid",
                           "foldedComponentIds": Array [],
                           "render": [Function],
-                          "styledComponentId": "Row__StyledRow-sc-1goz0ht-0",
+                          "styledComponentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
                           "target": "div",
                           "toString": [Function],
                           "warnTooManyClasses": [Function],
@@ -864,6 +859,8 @@ exports[`Tabs renders 1`] = `
                         }
                       }
                       forwardedRef={null}
+                      limitWidth={true}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -875,32 +872,19 @@ exports[`Tabs renders 1`] = `
                       }
                     >
                       <div
-                        className="c2"
+                        className="c1"
                       >
-                        <Col
-                          xs={12}
-                        >
-                          <Col__StyledCol
-                            gutter={false}
-                            hiddenLevel={
+                        <Row>
+                          <Row__StyledRow
+                            reverseLevel={
                               Array [
-                                12,
-                                12,
-                                12,
-                                12,
-                                12,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
                               ]
                             }
-                            horizontalAlignLevel={
-                              Array [
-                                "inherit",
-                                "inherit",
-                                "inherit",
-                                "inherit",
-                                "inherit",
-                              ]
-                            }
-                            xs={12}
                           >
                             <StyledComponent
                               forwardedComponent={
@@ -908,19 +892,20 @@ exports[`Tabs renders 1`] = `
                                   "$$typeof": Symbol(react.forward_ref),
                                   "attrs": Array [],
                                   "componentStyle": ComponentStyle {
-                                    "componentId": "Col__StyledCol-sc-15yvjc7-0",
+                                    "componentId": "Row__StyledRow-sc-1goz0ht-0",
                                     "isStatic": false,
-                                    "lastClassName": "c7",
+                                    "lastClassName": "c2",
                                     "rules": Array [
+                                      [Function],
                                       [Function],
                                       [Function],
                                       [Function],
                                     ],
                                   },
-                                  "displayName": "Col__StyledCol",
+                                  "displayName": "Row__StyledRow",
                                   "foldedComponentIds": Array [],
                                   "render": [Function],
-                                  "styledComponentId": "Col__StyledCol-sc-15yvjc7-0",
+                                  "styledComponentId": "Row__StyledRow-sc-1goz0ht-0",
                                   "target": "div",
                                   "toString": [Function],
                                   "warnTooManyClasses": [Function],
@@ -928,52 +913,830 @@ exports[`Tabs renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              gutter={false}
-                              hiddenLevel={
+                              reverseLevel={
                                 Array [
-                                  12,
-                                  12,
-                                  12,
-                                  12,
-                                  12,
+                                  false,
+                                  false,
+                                  false,
+                                  false,
+                                  false,
                                 ]
                               }
-                              horizontalAlignLevel={
-                                Array [
-                                  "inherit",
-                                  "inherit",
-                                  "inherit",
-                                  "inherit",
-                                  "inherit",
-                                ]
-                              }
-                              xs={12}
                             >
                               <div
-                                className="c3"
+                                className="c2"
                               >
-                                <Tabs
-                                  defaultFocus={false}
-                                  defaultIndex={null}
-                                  forceRenderTabPanel={false}
-                                  onSelect={[Function]}
-                                  selectedIndex={0}
+                                <Col
+                                  xs={12}
                                 >
-                                  <UncontrolledTabs
-                                    className="react-tabs"
-                                    focus={false}
-                                    forceRenderTabPanel={false}
-                                    onSelect={[Function]}
-                                    selectedIndex={0}
+                                  <Col__StyledCol
+                                    gutter={false}
+                                    hiddenLevel={
+                                      Array [
+                                        12,
+                                        12,
+                                        12,
+                                        12,
+                                        12,
+                                      ]
+                                    }
+                                    horizontalAlignLevel={
+                                      Array [
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                      ]
+                                    }
+                                    xs={12}
                                   >
-                                    <div
-                                      className="react-tabs"
-                                      data-tabs={true}
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "Col__StyledCol-sc-15yvjc7-0",
+                                            "isStatic": false,
+                                            "lastClassName": "c6",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Col__StyledCol",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "Col__StyledCol-sc-15yvjc7-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={null}
+                                      gutter={false}
+                                      hiddenLevel={
+                                        Array [
+                                          12,
+                                          12,
+                                          12,
+                                          12,
+                                          12,
+                                        ]
+                                      }
+                                      horizontalAlignLevel={
+                                        Array [
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                        ]
+                                      }
+                                      xs={12}
                                     >
-                                      <styles__TabBorder
-                                        key=".0"
+                                      <div
+                                        className="c3"
+                                      >
+                                        <styles__TabListContainer
+                                          key=".1"
+                                          positionToMove={0}
+                                        >
+                                          <StyledComponent
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "styles__TabListContainer-fcx45d-1",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c4",
+                                                  "rules": Array [
+                                                    "position:relative;transition:0.9s all ease;padding-right:24px;transform:translate(",
+                                                    [Function],
+                                                    "px);white-space:nowrap;",
+                                                  ],
+                                                },
+                                                "displayName": "styles__TabListContainer",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "styles__TabListContainer-fcx45d-1",
+                                                "target": "div",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={
+                                              Object {
+                                                "current": <div
+                                                  class="c4"
+                                                >
+                                                  <ul
+                                                    class="react-tabs__tab-list"
+                                                    role="tablist"
+                                                  >
+                                                    <li
+                                                      aria-controls="react-tabs-1"
+                                                      aria-disabled="false"
+                                                      aria-selected="true"
+                                                      class="react-tabs__tab react-tabs__tab--selected"
+                                                      id="react-tabs-0"
+                                                      role="tab"
+                                                      tabindex="0"
+                                                    >
+                                                      <h4
+                                                        class="c5"
+                                                      />
+                                                    </li>
+                                                    <li
+                                                      aria-controls="react-tabs-3"
+                                                      aria-disabled="false"
+                                                      aria-selected="false"
+                                                      class="react-tabs__tab"
+                                                      id="react-tabs-2"
+                                                      role="tab"
+                                                    >
+                                                      <h4
+                                                        class="c5"
+                                                      />
+                                                    </li>
+                                                    <li
+                                                      aria-controls="react-tabs-5"
+                                                      aria-disabled="false"
+                                                      aria-selected="false"
+                                                      class="react-tabs__tab"
+                                                      id="react-tabs-4"
+                                                      role="tab"
+                                                    >
+                                                      <h4
+                                                        class="c5"
+                                                      />
+                                                    </li>
+                                                  </ul>
+                                                </div>,
+                                              }
+                                            }
+                                            positionToMove={0}
+                                          >
+                                            <div
+                                              className="c4"
+                                            >
+                                              <TabList
+                                                className="react-tabs__tab-list"
+                                                key=".0"
+                                                style={
+                                                  Object {
+                                                    "width": undefined,
+                                                  }
+                                                }
+                                              >
+                                                <ul
+                                                  className="react-tabs__tab-list"
+                                                  role="tablist"
+                                                  style={
+                                                    Object {
+                                                      "width": undefined,
+                                                    }
+                                                  }
+                                                >
+                                                  <Tab
+                                                    className="react-tabs__tab"
+                                                    disabledClassName="react-tabs__tab--disabled"
+                                                    focus={false}
+                                                    id="react-tabs-0"
+                                                    key=".$0"
+                                                    onClick={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    panelId="react-tabs-1"
+                                                    selected={true}
+                                                    selectedClassName="react-tabs__tab--selected"
+                                                    tabRef={[Function]}
+                                                  >
+                                                    <li
+                                                      aria-controls="react-tabs-1"
+                                                      aria-disabled="false"
+                                                      aria-selected="true"
+                                                      className="react-tabs__tab react-tabs__tab--selected"
+                                                      id="react-tabs-0"
+                                                      onClick={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="tab"
+                                                      tabIndex="0"
+                                                    >
+                                                      <styles__TabLabel>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c5",
+                                                                "rules": Array [
+                                                                  "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
+                                                                ],
+                                                              },
+                                                              "displayName": "styles__TabLabel",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "target": "h4",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <h4
+                                                            className="c5"
+                                                          />
+                                                        </StyledComponent>
+                                                      </styles__TabLabel>
+                                                    </li>
+                                                  </Tab>
+                                                  <Tab
+                                                    className="react-tabs__tab"
+                                                    disabledClassName="react-tabs__tab--disabled"
+                                                    focus={false}
+                                                    id="react-tabs-2"
+                                                    key=".$177556"
+                                                    onClick={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    panelId="react-tabs-3"
+                                                    selected={false}
+                                                    selectedClassName="react-tabs__tab--selected"
+                                                    tabRef={[Function]}
+                                                  >
+                                                    <li
+                                                      aria-controls="react-tabs-3"
+                                                      aria-disabled="false"
+                                                      aria-selected="false"
+                                                      className="react-tabs__tab"
+                                                      id="react-tabs-2"
+                                                      onClick={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="tab"
+                                                      tabIndex={null}
+                                                    >
+                                                      <styles__TabLabel>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c5",
+                                                                "rules": Array [
+                                                                  "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
+                                                                ],
+                                                              },
+                                                              "displayName": "styles__TabLabel",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "target": "h4",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <h4
+                                                            className="c5"
+                                                          />
+                                                        </StyledComponent>
+                                                      </styles__TabLabel>
+                                                    </li>
+                                                  </Tab>
+                                                  <Tab
+                                                    className="react-tabs__tab"
+                                                    disabledClassName="react-tabs__tab--disabled"
+                                                    focus={false}
+                                                    id="react-tabs-4"
+                                                    key=".$177559"
+                                                    onClick={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    panelId="react-tabs-5"
+                                                    selected={false}
+                                                    selectedClassName="react-tabs__tab--selected"
+                                                    tabRef={[Function]}
+                                                  >
+                                                    <li
+                                                      aria-controls="react-tabs-5"
+                                                      aria-disabled="false"
+                                                      aria-selected="false"
+                                                      className="react-tabs__tab"
+                                                      id="react-tabs-4"
+                                                      onClick={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="tab"
+                                                      tabIndex={null}
+                                                    >
+                                                      <styles__TabLabel>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c5",
+                                                                "rules": Array [
+                                                                  "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
+                                                                ],
+                                                              },
+                                                              "displayName": "styles__TabLabel",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "target": "h4",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <h4
+                                                            className="c5"
+                                                          />
+                                                        </StyledComponent>
+                                                      </styles__TabLabel>
+                                                    </li>
+                                                  </Tab>
+                                                </ul>
+                                              </TabList>
+                                            </div>
+                                          </StyledComponent>
+                                        </styles__TabListContainer>
+                                      </div>
+                                    </StyledComponent>
+                                  </Col__StyledCol>
+                                </Col>
+                              </div>
+                            </StyledComponent>
+                          </Row__StyledRow>
+                        </Row>
+                      </div>
+                    </StyledComponent>
+                  </FlexGrid__StyledGrid>
+                </FlexGrid>
+              </FlexContainer>
+              <FlexContainer
+                key=".1"
+              >
+                <FlexGrid
+                  gutter={true}
+                  limitWidth={true}
+                  outsideGutter={true}
+                >
+                  <FlexGrid__StyledGrid
+                    limitWidth={true}
+                    outsideGutter={true}
+                    reverseLevel={
+                      Array [
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                      ]
+                    }
+                  >
+                    <StyledComponent
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
+                            "isStatic": false,
+                            "lastClassName": "c1",
+                            "rules": Array [
+                              [Function],
+                            ],
+                          },
+                          "displayName": "FlexGrid__StyledGrid",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
+                          "target": "div",
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
+                      limitWidth={true}
+                      outsideGutter={true}
+                      reverseLevel={
+                        Array [
+                          false,
+                          false,
+                          false,
+                          false,
+                          false,
+                        ]
+                      }
+                    >
+                      <div
+                        className="c1"
+                      >
+                        <Row>
+                          <Row__StyledRow
+                            reverseLevel={
+                              Array [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                              ]
+                            }
+                          >
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Row__StyledRow-sc-1goz0ht-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c2",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Row__StyledRow",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Row__StyledRow-sc-1goz0ht-0",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              reverseLevel={
+                                Array [
+                                  false,
+                                  false,
+                                  false,
+                                  false,
+                                  false,
+                                ]
+                              }
+                            >
+                              <div
+                                className="c2"
+                              >
+                                <Col
+                                  xs={12}
+                                >
+                                  <Col__StyledCol
+                                    gutter={true}
+                                    hiddenLevel={
+                                      Array [
+                                        12,
+                                        12,
+                                        12,
+                                        12,
+                                        12,
+                                      ]
+                                    }
+                                    horizontalAlignLevel={
+                                      Array [
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                        "inherit",
+                                      ]
+                                    }
+                                    xs={12}
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "Col__StyledCol-sc-15yvjc7-0",
+                                            "isStatic": false,
+                                            "lastClassName": "c6",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Col__StyledCol",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "Col__StyledCol-sc-15yvjc7-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={null}
+                                      gutter={true}
+                                      hiddenLevel={
+                                        Array [
+                                          12,
+                                          12,
+                                          12,
+                                          12,
+                                          12,
+                                        ]
+                                      }
+                                      horizontalAlignLevel={
+                                        Array [
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                          "inherit",
+                                        ]
+                                      }
+                                      xs={12}
+                                    >
+                                      <div
+                                        className="c6"
+                                      >
+                                        <Divider
+                                          key=".0"
+                                        >
+                                          <HairlineDivider
+                                            gradient={false}
+                                            vertical={false}
+                                          >
+                                            <HairlineDivider__StyledHairlineDivider
+                                              gradient={false}
+                                              vertical={false}
+                                            >
+                                              <StyledComponent
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "HairlineDivider__StyledHairlineDivider-biamlk-0",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c7",
+                                                      "rules": Array [
+                                                        "padding: 0;",
+                                                        "margin: 0;",
+                                                        "border-width: 0;",
+                                                        [Function],
+                                                      ],
+                                                    },
+                                                    "displayName": "HairlineDivider__StyledHairlineDivider",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "HairlineDivider__StyledHairlineDivider-biamlk-0",
+                                                    "target": "hr",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                gradient={false}
+                                                vertical={false}
+                                              >
+                                                <hr
+                                                  className="c7"
+                                                />
+                                              </StyledComponent>
+                                            </HairlineDivider__StyledHairlineDivider>
+                                          </HairlineDivider>
+                                          <div
+                                            style={
+                                              Object {
+                                                "height": "5px",
+                                              }
+                                            }
+                                          />
+                                          <DimpleDivider>
+                                            <DimpleDivider__StyledDimpleDivider>
+                                              <StyledComponent
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c8",
+                                                      "rules": Array [
+                                                        "padding: 0;",
+                                                        "margin: 0;",
+                                                        "border-width: 0;",
+                                                        "height: 32px;",
+                                                        "background-image: radial-gradient(ellipse at top, rgba(150, 150, 150, 0.1) 0%, rgba(0, 0, 0, 0) 70%);",
+                                                      ],
+                                                    },
+                                                    "displayName": "DimpleDivider__StyledDimpleDivider",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
+                                                    "target": "hr",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                              >
+                                                <hr
+                                                  className="c8"
+                                                />
+                                              </StyledComponent>
+                                            </DimpleDivider__StyledDimpleDivider>
+                                          </DimpleDivider>
+                                        </Divider>
+                                      </div>
+                                    </StyledComponent>
+                                  </Col__StyledCol>
+                                </Col>
+                              </div>
+                            </StyledComponent>
+                          </Row__StyledRow>
+                        </Row>
+                      </div>
+                    </StyledComponent>
+                  </FlexGrid__StyledGrid>
+                </FlexGrid>
+              </FlexContainer>
+              <TabPanel
+                className="react-tabs__tab-panel"
+                forceRender={false}
+                id="react-tabs-1"
+                key=".2:$0"
+                selected={true}
+                selectedClassName="react-tabs__tab-panel--selected"
+                tabId="react-tabs-0"
+              >
+                <div
+                  aria-labelledby="react-tabs-0"
+                  className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                  id="react-tabs-1"
+                  role="tabpanel"
+                >
+                  <FlexContainer
+                    tabIndex="0"
+                  >
+                    <FlexGrid
+                      gutter={true}
+                      limitWidth={true}
+                      outsideGutter={true}
+                    >
+                      <FlexGrid__StyledGrid
+                        limitWidth={true}
+                        outsideGutter={true}
+                        reverseLevel={
+                          Array [
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                          ]
+                        }
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
+                                "isStatic": false,
+                                "lastClassName": "c1",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "FlexGrid__StyledGrid",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
+                              "target": "div",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          limitWidth={true}
+                          outsideGutter={true}
+                          reverseLevel={
+                            Array [
+                              false,
+                              false,
+                              false,
+                              false,
+                              false,
+                            ]
+                          }
+                        >
+                          <div
+                            className="c1"
+                          >
+                            <Row>
+                              <Row__StyledRow
+                                reverseLevel={
+                                  Array [
+                                    false,
+                                    false,
+                                    false,
+                                    false,
+                                    false,
+                                  ]
+                                }
+                              >
+                                <StyledComponent
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Row__StyledRow-sc-1goz0ht-0",
+                                        "isStatic": false,
+                                        "lastClassName": "c2",
+                                        "rules": Array [
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Row__StyledRow",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Row__StyledRow-sc-1goz0ht-0",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  reverseLevel={
+                                    Array [
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                    ]
+                                  }
+                                >
+                                  <div
+                                    className="c2"
+                                  >
+                                    <Col
+                                      tabIndex="0"
+                                      xs={12}
+                                    >
+                                      <Col__StyledCol
+                                        gutter={true}
+                                        hiddenLevel={
+                                          Array [
+                                            12,
+                                            12,
+                                            12,
+                                            12,
+                                            12,
+                                          ]
+                                        }
+                                        horizontalAlignLevel={
+                                          Array [
+                                            "inherit",
+                                            "inherit",
+                                            "inherit",
+                                            "inherit",
+                                            "inherit",
+                                          ]
+                                        }
+                                        tabIndex="0"
+                                        xs={12}
                                       >
                                         <StyledComponent
                                           forwardedComponent={
@@ -981,17 +1744,19 @@ exports[`Tabs renders 1`] = `
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "styles__TabBorder-fcx45d-1",
+                                                "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                                 "isStatic": false,
-                                                "lastClassName": "c4",
+                                                "lastClassName": "c6",
                                                 "rules": Array [
-                                                  "border-bottom:1px solid #d8d8d8;overflow-x:hidden;margin-bottom:8px;&:after{content:'';position:absolute;top:52px;left:0;width:100%;height:32px;background-image:radial-gradient( at center top,rgba(150,150,150,0.1) 0%,rgba(0,0,0,0) 70% );padding:0px;margin:0px;border-width:0px;}",
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
                                                 ],
                                               },
-                                              "displayName": "styles__TabBorder",
+                                              "displayName": "Col__StyledCol",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "styles__TabBorder-fcx45d-1",
+                                              "styledComponentId": "Col__StyledCol-sc-15yvjc7-0",
                                               "target": "div",
                                               "toString": [Function],
                                               "warnTooManyClasses": [Function],
@@ -999,571 +1764,99 @@ exports[`Tabs renders 1`] = `
                                             }
                                           }
                                           forwardedRef={null}
+                                          gutter={true}
+                                          hiddenLevel={
+                                            Array [
+                                              12,
+                                              12,
+                                              12,
+                                              12,
+                                              12,
+                                            ]
+                                          }
+                                          horizontalAlignLevel={
+                                            Array [
+                                              "inherit",
+                                              "inherit",
+                                              "inherit",
+                                              "inherit",
+                                              "inherit",
+                                            ]
+                                          }
+                                          tabIndex="0"
+                                          xs={12}
                                         >
                                           <div
-                                            className="c4"
+                                            className="c6"
+                                            tabIndex="0"
                                           >
-                                            <styles__TabListContainer
-                                              key=".0"
-                                              positionToMove={0}
+                                            <Panel
+                                              copy="en"
+                                              onSelect={[Function]}
+                                              selectedIndex={0}
                                             >
-                                              <StyledComponent
-                                                forwardedComponent={
-                                                  Object {
-                                                    "$$typeof": Symbol(react.forward_ref),
-                                                    "attrs": Array [],
-                                                    "componentStyle": ComponentStyle {
-                                                      "componentId": "styles__TabListContainer-fcx45d-2",
-                                                      "isStatic": false,
-                                                      "lastClassName": "c5",
-                                                      "rules": Array [
-                                                        "position:relative;transition:0.9s all ease;padding-right:24px;transform:translate(",
-                                                        [Function],
-                                                        "px);white-space:nowrap;",
-                                                      ],
-                                                    },
-                                                    "displayName": "styles__TabListContainer",
-                                                    "foldedComponentIds": Array [],
-                                                    "render": [Function],
-                                                    "styledComponentId": "styles__TabListContainer-fcx45d-2",
-                                                    "target": "div",
-                                                    "toString": [Function],
-                                                    "warnTooManyClasses": [Function],
-                                                    "withComponent": [Function],
-                                                  }
-                                                }
-                                                forwardedRef={
-                                                  Object {
-                                                    "current": <div
-                                                      class="c5"
-                                                    >
-                                                      <ul
-                                                        class="react-tabs__tab-list"
-                                                        role="tablist"
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-1"
-                                                          aria-disabled="false"
-                                                          aria-selected="true"
-                                                          class="react-tabs__tab react-tabs__tab--selected"
-                                                          id="react-tabs-0"
-                                                          role="tab"
-                                                          tabindex="0"
-                                                        >
-                                                          <h4
-                                                            class="c6"
-                                                          />
-                                                        </li>
-                                                        <li
-                                                          aria-controls="react-tabs-3"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          class="react-tabs__tab"
-                                                          id="react-tabs-2"
-                                                          role="tab"
-                                                        >
-                                                          <h4
-                                                            class="c6"
-                                                          />
-                                                        </li>
-                                                        <li
-                                                          aria-controls="react-tabs-5"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          class="react-tabs__tab"
-                                                          id="react-tabs-4"
-                                                          role="tab"
-                                                        >
-                                                          <h4
-                                                            class="c6"
-                                                          />
-                                                        </li>
-                                                      </ul>
-                                                    </div>,
-                                                  }
-                                                }
-                                                positionToMove={0}
+                                              <div
+                                                copy="en"
+                                                onSelect={[Function]}
+                                                selectedIndex={0}
                                               >
-                                                <div
-                                                  className="c5"
-                                                >
-                                                  <TabList
-                                                    className="react-tabs__tab-list"
-                                                    key=".0"
-                                                    style={
-                                                      Object {
-                                                        "width": undefined,
-                                                      }
-                                                    }
-                                                  >
-                                                    <ul
-                                                      className="react-tabs__tab-list"
-                                                      role="tablist"
-                                                      style={
-                                                        Object {
-                                                          "width": undefined,
-                                                        }
-                                                      }
-                                                    >
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-0"
-                                                        key=".$0"
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-1"
-                                                        selected={true}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-1"
-                                                          aria-disabled="false"
-                                                          aria-selected="true"
-                                                          className="react-tabs__tab react-tabs__tab--selected"
-                                                          id="react-tabs-0"
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex="0"
-                                                        >
-                                                          <styles__TabLabel>
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabel-fcx45d-3",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c6",
-                                                                    "rules": Array [
-                                                                      "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabel",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                  "target": "h4",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                            >
-                                                              <h4
-                                                                className="c6"
-                                                              />
-                                                            </StyledComponent>
-                                                          </styles__TabLabel>
-                                                        </li>
-                                                      </Tab>
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-2"
-                                                        key=".$177556"
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-3"
-                                                        selected={false}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-3"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          className="react-tabs__tab"
-                                                          id="react-tabs-2"
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex={null}
-                                                        >
-                                                          <styles__TabLabel>
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabel-fcx45d-3",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c6",
-                                                                    "rules": Array [
-                                                                      "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabel",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                  "target": "h4",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                            >
-                                                              <h4
-                                                                className="c6"
-                                                              />
-                                                            </StyledComponent>
-                                                          </styles__TabLabel>
-                                                        </li>
-                                                      </Tab>
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-4"
-                                                        key=".$177559"
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-5"
-                                                        selected={false}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-5"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          className="react-tabs__tab"
-                                                          id="react-tabs-4"
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex={null}
-                                                        >
-                                                          <styles__TabLabel>
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabel-fcx45d-3",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c6",
-                                                                    "rules": Array [
-                                                                      "height:100%;display:block;padding-bottom:8px;border-bottom:4px solid transparent;",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabel",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                  "target": "h4",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                            >
-                                                              <h4
-                                                                className="c6"
-                                                              />
-                                                            </StyledComponent>
-                                                          </styles__TabLabel>
-                                                        </li>
-                                                      </Tab>
-                                                    </ul>
-                                                  </TabList>
-                                                </div>
-                                              </StyledComponent>
-                                            </styles__TabListContainer>
+                                                <Panel>
+                                                  <div>
+                                                    Content 1
+                                                  </div>
+                                                </Panel>
+                                              </div>
+                                            </Panel>
                                           </div>
                                         </StyledComponent>
-                                      </styles__TabBorder>
-                                      <TabPanel
-                                        className="react-tabs__tab-panel"
-                                        forceRender={false}
-                                        id="react-tabs-1"
-                                        key=".1:$0"
-                                        selected={true}
-                                        selectedClassName="react-tabs__tab-panel--selected"
-                                        tabId="react-tabs-0"
-                                      >
-                                        <div
-                                          aria-labelledby="react-tabs-0"
-                                          className="react-tabs__tab-panel react-tabs__tab-panel--selected"
-                                          id="react-tabs-1"
-                                          role="tabpanel"
-                                        >
-                                          <FlexGrid
-                                            gutter={true}
-                                            limitWidth={true}
-                                            outsideGutter={true}
-                                          >
-                                            <FlexGrid__StyledGrid
-                                              limitWidth={true}
-                                              outsideGutter={true}
-                                              reverseLevel={
-                                                Array [
-                                                  false,
-                                                  false,
-                                                  false,
-                                                  false,
-                                                  false,
-                                                ]
-                                              }
-                                            >
-                                              <StyledComponent
-                                                forwardedComponent={
-                                                  Object {
-                                                    "$$typeof": Symbol(react.forward_ref),
-                                                    "attrs": Array [],
-                                                    "componentStyle": ComponentStyle {
-                                                      "componentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
-                                                      "isStatic": false,
-                                                      "lastClassName": "c1",
-                                                      "rules": Array [
-                                                        [Function],
-                                                      ],
-                                                    },
-                                                    "displayName": "FlexGrid__StyledGrid",
-                                                    "foldedComponentIds": Array [],
-                                                    "render": [Function],
-                                                    "styledComponentId": "FlexGrid__StyledGrid-sc-1da2tb5-0",
-                                                    "target": "div",
-                                                    "toString": [Function],
-                                                    "warnTooManyClasses": [Function],
-                                                    "withComponent": [Function],
-                                                  }
-                                                }
-                                                forwardedRef={null}
-                                                limitWidth={true}
-                                                outsideGutter={true}
-                                                reverseLevel={
-                                                  Array [
-                                                    false,
-                                                    false,
-                                                    false,
-                                                    false,
-                                                    false,
-                                                  ]
-                                                }
-                                              >
-                                                <div
-                                                  className="c1"
-                                                >
-                                                  <Row>
-                                                    <Row__StyledRow
-                                                      reverseLevel={
-                                                        Array [
-                                                          false,
-                                                          false,
-                                                          false,
-                                                          false,
-                                                          false,
-                                                        ]
-                                                      }
-                                                    >
-                                                      <StyledComponent
-                                                        forwardedComponent={
-                                                          Object {
-                                                            "$$typeof": Symbol(react.forward_ref),
-                                                            "attrs": Array [],
-                                                            "componentStyle": ComponentStyle {
-                                                              "componentId": "Row__StyledRow-sc-1goz0ht-0",
-                                                              "isStatic": false,
-                                                              "lastClassName": "c2",
-                                                              "rules": Array [
-                                                                [Function],
-                                                                [Function],
-                                                                [Function],
-                                                                [Function],
-                                                              ],
-                                                            },
-                                                            "displayName": "Row__StyledRow",
-                                                            "foldedComponentIds": Array [],
-                                                            "render": [Function],
-                                                            "styledComponentId": "Row__StyledRow-sc-1goz0ht-0",
-                                                            "target": "div",
-                                                            "toString": [Function],
-                                                            "warnTooManyClasses": [Function],
-                                                            "withComponent": [Function],
-                                                          }
-                                                        }
-                                                        forwardedRef={null}
-                                                        reverseLevel={
-                                                          Array [
-                                                            false,
-                                                            false,
-                                                            false,
-                                                            false,
-                                                            false,
-                                                          ]
-                                                        }
-                                                      >
-                                                        <div
-                                                          className="c2"
-                                                        >
-                                                          <Col
-                                                            tabindex="0"
-                                                            xs={12}
-                                                          >
-                                                            <Col__StyledCol
-                                                              gutter={true}
-                                                              hiddenLevel={
-                                                                Array [
-                                                                  12,
-                                                                  12,
-                                                                  12,
-                                                                  12,
-                                                                  12,
-                                                                ]
-                                                              }
-                                                              horizontalAlignLevel={
-                                                                Array [
-                                                                  "inherit",
-                                                                  "inherit",
-                                                                  "inherit",
-                                                                  "inherit",
-                                                                  "inherit",
-                                                                ]
-                                                              }
-                                                              tabindex="0"
-                                                              xs={12}
-                                                            >
-                                                              <StyledComponent
-                                                                forwardedComponent={
-                                                                  Object {
-                                                                    "$$typeof": Symbol(react.forward_ref),
-                                                                    "attrs": Array [],
-                                                                    "componentStyle": ComponentStyle {
-                                                                      "componentId": "Col__StyledCol-sc-15yvjc7-0",
-                                                                      "isStatic": false,
-                                                                      "lastClassName": "c7",
-                                                                      "rules": Array [
-                                                                        [Function],
-                                                                        [Function],
-                                                                        [Function],
-                                                                      ],
-                                                                    },
-                                                                    "displayName": "Col__StyledCol",
-                                                                    "foldedComponentIds": Array [],
-                                                                    "render": [Function],
-                                                                    "styledComponentId": "Col__StyledCol-sc-15yvjc7-0",
-                                                                    "target": "div",
-                                                                    "toString": [Function],
-                                                                    "warnTooManyClasses": [Function],
-                                                                    "withComponent": [Function],
-                                                                  }
-                                                                }
-                                                                forwardedRef={null}
-                                                                gutter={true}
-                                                                hiddenLevel={
-                                                                  Array [
-                                                                    12,
-                                                                    12,
-                                                                    12,
-                                                                    12,
-                                                                    12,
-                                                                  ]
-                                                                }
-                                                                horizontalAlignLevel={
-                                                                  Array [
-                                                                    "inherit",
-                                                                    "inherit",
-                                                                    "inherit",
-                                                                    "inherit",
-                                                                    "inherit",
-                                                                  ]
-                                                                }
-                                                                tabindex="0"
-                                                                xs={12}
-                                                              >
-                                                                <div
-                                                                  className="c7"
-                                                                >
-                                                                  <Panel
-                                                                    copy="en"
-                                                                    onSelect={[Function]}
-                                                                    selectedIndex={0}
-                                                                  >
-                                                                    <div
-                                                                      copy="en"
-                                                                      onSelect={[Function]}
-                                                                      selectedIndex={0}
-                                                                    >
-                                                                      <Panel>
-                                                                        <div>
-                                                                          Content 1
-                                                                        </div>
-                                                                      </Panel>
-                                                                    </div>
-                                                                  </Panel>
-                                                                </div>
-                                                              </StyledComponent>
-                                                            </Col__StyledCol>
-                                                          </Col>
-                                                        </div>
-                                                      </StyledComponent>
-                                                    </Row__StyledRow>
-                                                  </Row>
-                                                </div>
-                                              </StyledComponent>
-                                            </FlexGrid__StyledGrid>
-                                          </FlexGrid>
-                                        </div>
-                                      </TabPanel>
-                                      <TabPanel
-                                        className="react-tabs__tab-panel"
-                                        forceRender={false}
-                                        id="react-tabs-3"
-                                        key=".1:$177556"
-                                        selected={false}
-                                        selectedClassName="react-tabs__tab-panel--selected"
-                                        tabId="react-tabs-2"
-                                      >
-                                        <div
-                                          aria-labelledby="react-tabs-2"
-                                          className="react-tabs__tab-panel"
-                                          id="react-tabs-3"
-                                          role="tabpanel"
-                                        />
-                                      </TabPanel>
-                                      <TabPanel
-                                        className="react-tabs__tab-panel"
-                                        forceRender={false}
-                                        id="react-tabs-5"
-                                        key=".1:$177559"
-                                        selected={false}
-                                        selectedClassName="react-tabs__tab-panel--selected"
-                                        tabId="react-tabs-4"
-                                      >
-                                        <div
-                                          aria-labelledby="react-tabs-4"
-                                          className="react-tabs__tab-panel"
-                                          id="react-tabs-5"
-                                          role="tabpanel"
-                                        />
-                                      </TabPanel>
-                                    </div>
-                                  </UncontrolledTabs>
-                                </Tabs>
-                              </div>
-                            </StyledComponent>
-                          </Col__StyledCol>
-                        </Col>
-                      </div>
-                    </StyledComponent>
-                  </Row__StyledRow>
-                </Row>
-              </div>
-            </StyledComponent>
-          </FlexGrid__StyledGrid>
-        </FlexGrid>
+                                      </Col__StyledCol>
+                                    </Col>
+                                  </div>
+                                </StyledComponent>
+                              </Row__StyledRow>
+                            </Row>
+                          </div>
+                        </StyledComponent>
+                      </FlexGrid__StyledGrid>
+                    </FlexGrid>
+                  </FlexContainer>
+                </div>
+              </TabPanel>
+              <TabPanel
+                className="react-tabs__tab-panel"
+                forceRender={false}
+                id="react-tabs-3"
+                key=".2:$177556"
+                selected={false}
+                selectedClassName="react-tabs__tab-panel--selected"
+                tabId="react-tabs-2"
+              >
+                <div
+                  aria-labelledby="react-tabs-2"
+                  className="react-tabs__tab-panel"
+                  id="react-tabs-3"
+                  role="tabpanel"
+                />
+              </TabPanel>
+              <TabPanel
+                className="react-tabs__tab-panel"
+                forceRender={false}
+                id="react-tabs-5"
+                key=".2:$177559"
+                selected={false}
+                selectedClassName="react-tabs__tab-panel--selected"
+                tabId="react-tabs-4"
+              >
+                <div
+                  aria-labelledby="react-tabs-4"
+                  className="react-tabs__tab-panel"
+                  id="react-tabs-5"
+                  role="tabpanel"
+                />
+              </TabPanel>
+            </div>
+          </UncontrolledTabs>
+        </Tabs>
       </div>
     </StyledComponent>
   </styles__TabsContainer>

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -16,7 +16,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c8 {
+.c9 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -146,6 +146,10 @@ exports[`Tabs renders 1`] = `
   -ms-transform: translate(0px);
   transform: translate(0px);
   white-space: nowrap;
+}
+
+.c8 {
+  height: '5px';
 }
 
 .c5 {
@@ -363,7 +367,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c8 {
+.c9 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -493,6 +497,10 @@ exports[`Tabs renders 1`] = `
   -ms-transform: translate(0px);
   transform: translate(0px);
   white-space: nowrap;
+}
+
+.c8 {
+  height: '5px';
 }
 
 .c5 {
@@ -734,10 +742,10 @@ exports[`Tabs renders 1`] = `
                       class="c7"
                     />
                     <div
-                      style="height: 5px;"
+                      class="c8"
                     />
                     <hr
-                      class="c8"
+                      class="c9"
                     />
                   </div>
                 </div>
@@ -1134,7 +1142,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "componentId": "styles__TabLabel-fcx45d-3",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1144,7 +1152,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1191,7 +1199,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "componentId": "styles__TabLabel-fcx45d-3",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1201,7 +1209,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1248,7 +1256,7 @@ exports[`Tabs renders 1`] = `
                                                               "$$typeof": Symbol(react.forward_ref),
                                                               "attrs": Array [],
                                                               "componentStyle": ComponentStyle {
-                                                                "componentId": "styles__TabLabel-fcx45d-2",
+                                                                "componentId": "styles__TabLabel-fcx45d-3",
                                                                 "isStatic": false,
                                                                 "lastClassName": "c5",
                                                                 "rules": Array [
@@ -1258,7 +1266,7 @@ exports[`Tabs renders 1`] = `
                                                               "displayName": "styles__TabLabel",
                                                               "foldedComponentIds": Array [],
                                                               "render": [Function],
-                                                              "styledComponentId": "styles__TabLabel-fcx45d-2",
+                                                              "styledComponentId": "styles__TabLabel-fcx45d-3",
                                                               "target": "h4",
                                                               "toString": [Function],
                                                               "warnTooManyClasses": [Function],
@@ -1526,13 +1534,37 @@ exports[`Tabs renders 1`] = `
                                               </StyledComponent>
                                             </HairlineDivider__StyledHairlineDivider>
                                           </HairlineDivider>
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": "5px",
+                                          <styles__SandwichFilling>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "styles__SandwichFilling-fcx45d-2",
+                                                    "isStatic": false,
+                                                    "lastClassName": "c8",
+                                                    "rules": Array [
+                                                      "height:'5px';",
+                                                    ],
+                                                  },
+                                                  "displayName": "styles__SandwichFilling",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "styles__SandwichFilling-fcx45d-2",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
                                               }
-                                            }
-                                          />
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="c8"
+                                              />
+                                            </StyledComponent>
+                                          </styles__SandwichFilling>
                                           <DimpleDivider>
                                             <DimpleDivider__StyledDimpleDivider>
                                               <StyledComponent
@@ -1543,7 +1575,7 @@ exports[`Tabs renders 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "c8",
+                                                      "lastClassName": "c9",
                                                       "rules": Array [
                                                         "padding: 0;",
                                                         "margin: 0;",
@@ -1565,7 +1597,7 @@ exports[`Tabs renders 1`] = `
                                                 forwardedRef={null}
                                               >
                                                 <hr
-                                                  className="c8"
+                                                  className="c9"
                                                 />
                                               </StyledComponent>
                                             </DimpleDivider__StyledDimpleDivider>

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -309,10 +309,14 @@ exports[`Tabs renders 1`] = `
 <Tabs
   copy="en"
   leftArrowLabel="Move menu to the left"
+  onSelect={[Function]}
   rightArrowLabel="Move menu to the right"
+  selectedIndex={0}
 >
   <styles__TabsContainer
     copy="en"
+    onSelect={[Function]}
+    selectedIndex={0}
   >
     <StyledComponent
       copy="en"
@@ -728,6 +732,7 @@ exports[`Tabs renders 1`] = `
                           >
                             <div
                               copy="en"
+                              selectedindex="0"
                             >
                               <div>
                                 Content 1
@@ -756,9 +761,12 @@ exports[`Tabs renders 1`] = `
           </div>,
         }
       }
+      onSelect={[Function]}
+      selectedIndex={0}
     >
       <div
         className="c0"
+        onSelect={[Function]}
       >
         <FlexGrid
           gutter={false}
@@ -948,7 +956,8 @@ exports[`Tabs renders 1`] = `
                                   defaultFocus={false}
                                   defaultIndex={null}
                                   forceRenderTabPanel={false}
-                                  selectedIndex={null}
+                                  onSelect={[Function]}
+                                  selectedIndex={0}
                                 >
                                   <UncontrolledTabs
                                     className="react-tabs"
@@ -1479,9 +1488,13 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <Panel
                                                                     copy="en"
+                                                                    onSelect={[Function]}
+                                                                    selectedIndex={0}
                                                                   >
                                                                     <div
                                                                       copy="en"
+                                                                      onSelect={[Function]}
+                                                                      selectedIndex={0}
                                                                     >
                                                                       <Panel>
                                                                         <div>

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -316,15 +316,15 @@ exports[`Tabs renders 1`] = `
 <Tabs
   copy="en"
   leftArrowLabel="Move menu to the left"
-  onSelect={[Function]}
+  onOpen={[Function]}
+  open={null}
   rightArrowLabel="Move menu to the right"
-  selectedIndex={0}
   stretch={false}
 >
   <styles__TabsContainer
     copy="en"
-    onSelect={[Function]}
-    selectedIndex={0}
+    onOpen={[Function]}
+    open={null}
   >
     <StyledComponent
       copy="en"
@@ -768,9 +768,10 @@ exports[`Tabs renders 1`] = `
                     >
                       <div
                         copy="en"
-                        selectedindex="0"
                       >
-                        <div>
+                        <div
+                          id="1"
+                        >
                           Content 1
                         </div>
                       </div>
@@ -794,12 +795,13 @@ exports[`Tabs renders 1`] = `
           </div>,
         }
       }
-      onSelect={[Function]}
-      selectedIndex={0}
+      onOpen={[Function]}
+      open={null}
     >
       <div
         className="c0"
-        onSelect={[Function]}
+        onOpen={[Function]}
+        open={null}
       >
         <Tabs
           defaultFocus={false}
@@ -1824,16 +1826,20 @@ exports[`Tabs renders 1`] = `
                                           >
                                             <Panel
                                               copy="en"
-                                              onSelect={[Function]}
-                                              selectedIndex={0}
+                                              onOpen={[Function]}
+                                              open={null}
                                             >
                                               <div
                                                 copy="en"
-                                                onSelect={[Function]}
-                                                selectedIndex={0}
+                                                onOpen={[Function]}
+                                                open={null}
                                               >
-                                                <Panel>
-                                                  <div>
+                                                <Panel
+                                                  id="1"
+                                                >
+                                                  <div
+                                                    id="1"
+                                                  >
                                                     Content 1
                                                   </div>
                                                 </Panel>

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -91,7 +91,7 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 .react-tabs__tab-list {
-  padding: 1px 0;
+  padding: 0;
 }
 
 .c0 .react-tabs__tab {
@@ -333,7 +333,7 @@ exports[`Tabs renders 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:1px 0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 0;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{box-shadow:0 0 0 2px #979797;border-radius:4px;outline:none;h4{border-bottom:none;}}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;}}",
+              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 0;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{box-shadow:0 0 0 2px #979797;border-radius:4px;outline:none;h4{border-bottom:none;}}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;}}",
             ],
           },
           "displayName": "styles__TabsContainer",
@@ -438,7 +438,7 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 .react-tabs__tab-list {
-  padding: 1px 0;
+  padding: 0;
 }
 
 .c0 .react-tabs__tab {

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -149,7 +149,7 @@ exports[`Tabs renders 1`] = `
 }
 
 .c8 {
-  height: '5px';
+  height: 5px;
 }
 
 .c5 {
@@ -500,7 +500,7 @@ exports[`Tabs renders 1`] = `
 }
 
 .c8 {
-  height: '5px';
+  height: 5px;
 }
 
 .c5 {
@@ -1545,7 +1545,7 @@ exports[`Tabs renders 1`] = `
                                                     "isStatic": false,
                                                     "lastClassName": "c8",
                                                     "rules": Array [
-                                                      "height:'5px';",
+                                                      "height:5px;",
                                                     ],
                                                   },
                                                   "displayName": "styles__SandwichFilling",

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -50,30 +50,7 @@ export const TabsContainer = styled.div`
 
     &.react-tabs__tab-panel--selected {
       display: block;
-      margin-top: 24px;
     }
-  }
-`
-
-export const TabBorder = styled.div`
-  border-bottom: 1px solid #d8d8d8;
-  overflow-x: hidden;
-  margin-bottom: 8px;
-  &:after {
-    content: '';
-    position: absolute;
-    top: 52px;
-    left: 0;
-    width: 100%;
-    height: 32px;
-    background-image: radial-gradient(
-      at center top,
-      rgba(150, 150, 150, 0.1) 0%,
-      rgba(0, 0, 0, 0) 70%
-    );
-    padding: 0px;
-    margin: 0px;
-    border-width: 0px;
   }
 `
 

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -62,10 +62,6 @@ export const TabListContainer = styled.div`
   white-space: nowrap;
 `
 
-export const SandwichFilling = styled.div`
-  height: 5px;
-`
-
 export const TabLabel = styled.h4`
   height: 100%;
   display: block;

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -7,7 +7,7 @@ export const TabsContainer = styled.div`
     position: relative;
   }
   .react-tabs__tab-list {
-    padding: 1px 0;
+    padding: 0;
   }
   .react-tabs__tab {
     display: inline-block;

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -62,6 +62,10 @@ export const TabListContainer = styled.div`
   white-space: nowrap;
 `
 
+export const SandwichFilling = styled.div`
+  height: '5px';
+`
+
 export const TabLabel = styled.h4`
   height: 100%;
   display: block;

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -63,7 +63,7 @@ export const TabListContainer = styled.div`
 `
 
 export const SandwichFilling = styled.div`
-  height: '5px';
+  height: 5px;
 `
 
 export const TabLabel = styled.h4`


### PR DESCRIPTION
Allows tabs to be controlled externally.

As per with the accordion control, we use the prop `open`, to pass in the id (string) of the tab to open (on accordion it is an array, here it is a single string because only one tab can be open at a time).

As tabs are clicked, an onOpen event is raised with the param 
- `newId` the tab clicked
- `previousId` the tab we just left
- `event` the event raised on click
If you return false, the event is cancelled as per `react-tabs`.

Also added a `stretch` prop to allow the border to stretch to 100% of the parent component (we need this for the optik channel selection designs)

![image](https://user-images.githubusercontent.com/36038467/101197626-a81b7a00-3662-11eb-86fa-1efeae2d85af.png)

Also, updated to use the hairline and dimple dividers to re-use standard dividers
