### PR TITLE
fix(community-input-group): hr-1605 double border fix for safari

### DIFF
--- a/packages/InputGroup/style.js
+++ b/packages/InputGroup/style.js
@@ -23,6 +23,7 @@ export const InputGroupStyle = styled.div(({ hasValue }) => ({
     },
   },
   input: {
+    marginLeft: 0,
     height: '100%',
     borderLeft: '1px solid #D8D8D8',
     borderTop: '1px solid #D8D8D8',


### PR DESCRIPTION
## Related issues

See [HR-1605](https://telusdigital.atlassian.net/browse/HR-1605)

## Description

- Double border was appearing on safari browsers, this PR, explicitly removes the margin to align the text box with the left of the container

![input-group-bug-safari](https://user-images.githubusercontent.com/36038467/101517779-67cd3c00-3981-11eb-90ee-8b49412118da.gif)


## Checklist before submitting pull request
- [x] New code is unit tested (did not change any snapshots)
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
