### PR TITLE
feat(community-tabs): add support for wrapping labels

### DIFF
--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -104,7 +104,9 @@ const Tabs = props => {
   const getTabsWidth = () => {
     let tabsWidthValue = 0
     const tabsArray =
-      tabRef.current && tabRef.current.children[0] && tabRef.current.children[0].childNodes
+      tabRef.current &&
+      tabRef.current.children[0] &&
+      Array.from(tabRef.current.children[0].childNodes)
     const firstTab =
       tabRef.current && tabRef.current.children[0] && tabRef.current.children[0].firstChild
     const lastTab =
@@ -274,7 +276,11 @@ const Tabs = props => {
                   </TabArrows>
                 )}
                 <TabListOuterContainer>
-                  <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
+                  <TabListContainer
+                    ref={tabRef}
+                    positionToMove={tabsTranslatePosition}
+                    wrapLabels={wrapLabels}
+                  >
                     <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
                   </TabListContainer>
                 </TabListOuterContainer>

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -9,6 +9,7 @@ import DimpleDivider from '@tds/core-dimple-divider'
 import {
   TabsContainer,
   TabBorder,
+  TabListOuterContainer,
   TabListContainer,
   TabLabel,
   TabArrows,
@@ -45,7 +46,7 @@ const Tabs = props => {
   const [isRightArrowVisible, setRightArrowVisible] = useState(false)
   const [current, setCurrent] = useState(0)
   const [currentFocus, setCurrentFocus] = useState(0)
-  const { children, leftArrowLabel, rightArrowLabel, ...rest } = props
+  const { children, leftArrowLabel, rightArrowLabel, wrapLabels, ...rest } = props
 
   useEffect(() => {
     // if open is null or undefined it is uncontrolled
@@ -250,49 +251,51 @@ const Tabs = props => {
   }, [])
 
   return (
-    <TabsContainer {...safeRest(rest)} ref={tabsRoot}>
+    <TabsContainer {...safeRest(rest)} wrapLabels={wrapLabels} ref={tabsRoot}>
       <FlexGrid gutter={false}>
         <FlexGrid.Row>
           <FlexGrid.Col xs={12}>
-            {isLeftArrowVisible && (
-              <TabArrows
-                tabIndex="0"
-                direction="left"
-                aria-label={leftArrowLabel}
-                onKeyUp={e => handleArrowKeyUp(e, 'left')}
-                onClick={() => scrollTabs('left')}
-              >
-                <ArrowInner direction="left">
-                  <ChevronLeft variant="basic" />
-                </ArrowInner>
-              </TabArrows>
-            )}
             <ReactTabs
               selectedIndex={props.open && current}
               onSelect={props.onOpen && handleSelect}
             >
               <TabBorder>
-                <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
-                  <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
-                </TabListContainer>
+                {isLeftArrowVisible && (
+                  <TabArrows
+                    tabIndex="0"
+                    direction="left"
+                    aria-label={leftArrowLabel}
+                    onKeyUp={e => handleArrowKeyUp(e, 'left')}
+                    onClick={() => scrollTabs('left')}
+                  >
+                    <ArrowInner direction="left">
+                      <ChevronLeft variant="basic" />
+                    </ArrowInner>
+                  </TabArrows>
+                )}
+                <TabListOuterContainer>
+                  <TabListContainer ref={tabRef} positionToMove={tabsTranslatePosition}>
+                    <TabList style={{ width: tabsContainerWidth }}>{mapTabs()}</TabList>
+                  </TabListContainer>
+                </TabListOuterContainer>
+                {isRightArrowVisible && (
+                  <TabArrows
+                    tabIndex="0"
+                    direction="right"
+                    onKeyUp={e => handleArrowKeyUp(e, 'right')}
+                    aria-label={rightArrowLabel}
+                    onClick={() => scrollTabs('right')}
+                  >
+                    <ArrowInner direction="right">
+                      <ChevronRight variant="basic" />
+                    </ArrowInner>
+                  </TabArrows>
+                )}
               </TabBorder>
               <HairlineDivider />
               <DimpleDivider />
               {mapTabContent()}
             </ReactTabs>
-            {isRightArrowVisible && (
-              <TabArrows
-                tabIndex="0"
-                direction="right"
-                onKeyUp={e => handleArrowKeyUp(e, 'right')}
-                aria-label={rightArrowLabel}
-                onClick={() => scrollTabs('right')}
-              >
-                <ArrowInner direction="right">
-                  <ChevronRight variant="basic" />
-                </ArrowInner>
-              </TabArrows>
-            )}
           </FlexGrid.Col>
         </FlexGrid.Row>
       </FlexGrid>
@@ -308,6 +311,10 @@ Tabs.propTypes = {
   leftArrowLabel: PropTypes.string,
   rightArrowLabel: PropTypes.string,
   /**
+   * Allow tab labels to wrap to multiple lines
+   */
+  wrapLabels: PropTypes.bool,
+  /**
    * Set the selected tab by id
    */
   open: PropTypes.string,
@@ -320,6 +327,7 @@ Tabs.propTypes = {
 Tabs.defaultProps = {
   leftArrowLabel: 'Move menu to the left',
   rightArrowLabel: 'Move menu to the right',
+  wrapLabels: false,
   open: null,
   onOpen: null,
 }

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -46,14 +46,14 @@ const Tabs = props => {
   const [isRightArrowVisible, setRightArrowVisible] = useState(false)
   const [current, setCurrent] = useState(0)
   const [currentFocus, setCurrentFocus] = useState(0)
-  const { children, leftArrowLabel, rightArrowLabel, wrapLabels, ...rest } = props
+  const { children, leftArrowLabel, rightArrowLabel, wrapLabels, open, onOpen, ...rest } = props
 
   useEffect(() => {
     // if open is null or undefined it is uncontrolled
     // empty string may be a valid input to select no tabs (this case is required)
-    if (props.open === null || props.open === undefined) return
+    if (open === null || open === undefined) return
     if (!props.children.length) return
-    const tabIndex = props.children.findIndex(child => child.props.id === props.open)
+    const tabIndex = props.children.findIndex(child => child.props.id === open)
 
     if (tabIndex >= 0) {
       setCurrent(tabIndex)
@@ -62,12 +62,12 @@ const Tabs = props => {
     }
     // if tabIndex === null set to -1 to keep tabs contolled, but select no tab
     setCurrent(-1)
-  }, [props.open])
+  }, [open])
 
   const handleBlur = () => {
     // on blur in controlled mode, we set the index back to prop value
-    if (props.open === null || props.open === undefined) return
-    const tabIndex = props.children.findIndex(child => child.props.id === props.open)
+    if (open === null || open === undefined) return
+    const tabIndex = props.children.findIndex(child => child.props.id === open)
     if (tabIndex !== current) {
       setCurrent(tabIndex)
       setCurrentFocus(tabIndex)
@@ -76,13 +76,13 @@ const Tabs = props => {
 
   const handleClick = (e, index) => {
     e.preventDefault()
-    if (!props.open) {
+    if (!open) {
       setCurrent(index) // set internally if not-controlled
       setCurrentFocus(index)
       return
     }
     // raise to controlling component to set on click if controlled
-    props.onOpen(props.children[index].props.id)
+    onOpen(props.children[index].props.id)
   }
 
   const handleSelect = (index, previousIndex) => {
@@ -97,7 +97,7 @@ const Tabs = props => {
     const previousTab = props.children[previousIndex]
     if (newTab === previousTab) {
       // this is on a tab switch
-      props.onOpen(newTab.props.id)
+      onOpen(newTab.props.id)
     }
   }
 
@@ -217,7 +217,7 @@ const Tabs = props => {
             onKeyUp={e => handleTabsKeyUp(e)}
             ref={tabNavRef}
           >
-            <TabLabelContainer tabIndex={isActive && '-1'}>
+            <TabLabelContainer tabIndex={isActive ? '-1' : undefined}>
               <TabLabel wrapLabel={wrapLabels}>{tab.props.heading}</TabLabel>
             </TabLabelContainer>
           </Tab>
@@ -234,7 +234,7 @@ const Tabs = props => {
           <TabPanel key={hash(i)}>
             <FlexGrid>
               <FlexGrid.Row>
-                <FlexGrid.Col xs={12} tabindex="0">
+                <FlexGrid.Col xs={12} tabIndex="0">
                   <Panel {...rest}>{children[current]}</Panel>
                 </FlexGrid.Col>
               </FlexGrid.Row>
@@ -258,8 +258,8 @@ const Tabs = props => {
         <FlexGrid.Row>
           <FlexGrid.Col xs={12}>
             <ReactTabs
-              selectedIndex={props.open && current}
-              onSelect={props.onOpen && handleSelect}
+              selectedIndex={open ? current : undefined}
+              onSelect={onOpen ? handleSelect : undefined}
             >
               <TabBorder>
                 {isLeftArrowVisible && (

--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -215,8 +215,8 @@ const Tabs = props => {
             onKeyUp={e => handleTabsKeyUp(e)}
             ref={tabNavRef}
           >
-            <TabLabelContainer tabIndex={isActive && '-1'} isActive={isActive}>
-              <TabLabel>{tab.props.heading}</TabLabel>
+            <TabLabelContainer tabIndex={isActive && '-1'}>
+              <TabLabel wrapLabel={wrapLabels}>{tab.props.heading}</TabLabel>
             </TabLabelContainer>
           </Tab>
         )

--- a/packages/Tabs/Tabs.md
+++ b/packages/Tabs/Tabs.md
@@ -32,11 +32,34 @@ Note that the `copy` prop must be provided at all times for the correct accessib
 </Tabs>
 ```
 
+#### Multiline Labels
+
+If the labels are long, particularly in French, you can use the optional `wrapLabels` prop to limit the maximum width of labels to 144px, wrapping as necessary. It is recommended that labels are 35 characters or fewer.
+
+```jsx
+const longLabels = [
+  'Cliniques et médecins',
+  'Pharmacies',
+  'Professionnels de la santé affiliés',
+  'Régime collectif d’assurance santé',
+  'Régies de la santé et hôpitaux',
+  'Solutions de santé personnelle',
+];
+
+<Tabs copy="fr" wrapLabels>
+  {longLabels.map(label => (
+    <Tabs.Panel heading={label} key={label}>
+      {label}
+    </Tabs.Panel>
+  ))}
+</Tabs>
+```
+
 ### Controlled Example
 
 Use the `open` and `onOpen` props to control the component externally.
 
-To use controlled mode, you must specify an `id` (string) on each `<Tab.Panel>`.
+To use controlled mode, you must specify an `id` (string) on each `<Tabs.Panel>`.
 You can then use the `open` prop on `<Tabs>` to pass in the `id` of the tab you want to open.
 
 When a user selects a tab, the event `onOpen(id)` will be raised, where `id` is the id of the tab clicked.

--- a/packages/Tabs/__tests__/Tabs.spec.jsx
+++ b/packages/Tabs/__tests__/Tabs.spec.jsx
@@ -9,9 +9,15 @@ describe('Tabs', () => {
   const doMount = (props = {}) =>
     mount(
       <Tabs copy="en" {...props}>
-        <Tabs.Panel id="1">Content 1</Tabs.Panel>
-        <Tabs.Panel id="2">Content 2</Tabs.Panel>
-        <Tabs.Panel id="3">Content 3</Tabs.Panel>
+        <Tabs.Panel id="1" heading="Label 1">
+          Content 1
+        </Tabs.Panel>
+        <Tabs.Panel id="2" heading="Label 2">
+          Content 2
+        </Tabs.Panel>
+        <Tabs.Panel id="3" heading="Label 3">
+          Content 3
+        </Tabs.Panel>
       </Tabs>
     )
 
@@ -26,7 +32,8 @@ describe('Tabs', () => {
   })
 
   it('selects a tab', () => {
-    const tabs = doMount({ open: '2' })
+    const onOpen = jest.fn()
+    const tabs = doMount({ open: '2', onOpen })
     expect(tabs).toHaveProp('open', '2')
     expect(tabs.text()).toContain('Content 2')
     expect(tabs.text()).not.toContain('Content 1')

--- a/packages/Tabs/__tests__/Tabs.spec.jsx
+++ b/packages/Tabs/__tests__/Tabs.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import 'jest-styled-components'
 
 import Tabs from '../Tabs'
 
@@ -46,5 +47,11 @@ describe('Tabs', () => {
       .simulate('click')
     expect(tabs.text()).toContain('Content 2')
     expect(onOpen).toHaveBeenCalledWith('2')
+  })
+
+  it('renders with multiline labels', () => {
+    const tabs = doMount({ wrapLabels: true })
+    const tab = tabs.find('.react-tabs__tab').first()
+    expect(tab).toHaveStyleRule({ 'max-width': '180px' })
   })
 })

--- a/packages/Tabs/__tests__/Tabs.spec.jsx
+++ b/packages/Tabs/__tests__/Tabs.spec.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import 'jest-styled-components'
 
 import Tabs from '../Tabs'
+import { TabLabel } from '../styles'
 
 describe('Tabs', () => {
   const doMount = (props = {}) =>
@@ -51,7 +52,8 @@ describe('Tabs', () => {
 
   it('renders with multiline labels', () => {
     const tabs = doMount({ wrapLabels: true })
-    const tab = tabs.find('.react-tabs__tab').first()
-    expect(tab).toHaveStyleRule({ 'max-width': '180px' })
+    const tabLabel = tabs.find(TabLabel).first()
+    expect(tabs).toHaveProp('wrapLabels', true)
+    expect(tabLabel).toHaveStyleRule('max-width', '144px')
   })
 })

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -386,8 +386,6 @@ exports[`Tabs renders 1`] = `
 >
   <styles__TabsContainer
     copy="en"
-    onOpen={null}
-    open={null}
     wrapLabels={false}
   >
     <StyledComponent
@@ -824,6 +822,7 @@ exports[`Tabs renders 1`] = `
                             <li
                               aria-controls="react-tabs-1"
                               aria-disabled="false"
+                              aria-label="Label 1"
                               aria-selected="true"
                               class="react-tabs__tab react-tabs__tab--selected"
                               id="react-tabs-0"
@@ -836,12 +835,15 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
-                                />
+                                >
+                                  Label 1
+                                </h4>
                               </button>
                             </li>
                             <li
                               aria-controls="react-tabs-3"
                               aria-disabled="false"
+                              aria-label="Label 2"
                               aria-selected="false"
                               class="react-tabs__tab"
                               id="react-tabs-2"
@@ -853,12 +855,15 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
-                                />
+                                >
+                                  Label 2
+                                </h4>
                               </button>
                             </li>
                             <li
                               aria-controls="react-tabs-5"
                               aria-disabled="false"
+                              aria-label="Label 3"
                               aria-selected="false"
                               class="react-tabs__tab"
                               id="react-tabs-4"
@@ -870,7 +875,9 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
-                                />
+                                >
+                                  Label 3
+                                </h4>
                               </button>
                             </li>
                           </ul>
@@ -897,11 +904,13 @@ exports[`Tabs renders 1`] = `
                         >
                           <div
                             class="c10"
+                            tabindex="0"
                           >
                             <div
                               copy="en"
                             >
                               <div
+                                heading="Label 1"
                                 id="1"
                               >
                                 Content 1
@@ -930,14 +939,10 @@ exports[`Tabs renders 1`] = `
           </div>,
         }
       }
-      onOpen={null}
-      open={null}
       wrapLabels={false}
     >
       <div
         className="c0"
-        onOpen={null}
-        open={null}
       >
         <FlexGrid
           gutter={false}
@@ -1127,7 +1132,6 @@ exports[`Tabs renders 1`] = `
                                   defaultFocus={false}
                                   defaultIndex={null}
                                   forceRenderTabPanel={false}
-                                  onSelect={null}
                                   selectedIndex={null}
                                 >
                                   <UncontrolledTabs
@@ -1249,6 +1253,7 @@ exports[`Tabs renders 1`] = `
                                                               <li
                                                                 aria-controls="react-tabs-1"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 1"
                                                                 aria-selected="true"
                                                                 class="react-tabs__tab react-tabs__tab--selected"
                                                                 id="react-tabs-0"
@@ -1261,12 +1266,15 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
-                                                                  />
+                                                                  >
+                                                                    Label 1
+                                                                  </h4>
                                                                 </button>
                                                               </li>
                                                               <li
                                                                 aria-controls="react-tabs-3"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 2"
                                                                 aria-selected="false"
                                                                 class="react-tabs__tab"
                                                                 id="react-tabs-2"
@@ -1278,12 +1286,15 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
-                                                                  />
+                                                                  >
+                                                                    Label 2
+                                                                  </h4>
                                                                 </button>
                                                               </li>
                                                               <li
                                                                 aria-controls="react-tabs-5"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 3"
                                                                 aria-selected="false"
                                                                 class="react-tabs__tab"
                                                                 id="react-tabs-4"
@@ -1295,7 +1306,9 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
-                                                                  />
+                                                                  >
+                                                                    Label 3
+                                                                  </h4>
                                                                 </button>
                                                               </li>
                                                             </ul>
@@ -1327,6 +1340,7 @@ exports[`Tabs renders 1`] = `
                                                             }
                                                           >
                                                             <Tab
+                                                              aria-label="Label 1"
                                                               className="react-tabs__tab"
                                                               disabledClassName="react-tabs__tab--disabled"
                                                               focus={false}
@@ -1344,6 +1358,7 @@ exports[`Tabs renders 1`] = `
                                                               <li
                                                                 aria-controls="react-tabs-1"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 1"
                                                                 aria-selected="true"
                                                                 className="react-tabs__tab react-tabs__tab--selected"
                                                                 id="react-tabs-0"
@@ -1444,7 +1459,9 @@ exports[`Tabs renders 1`] = `
                                                                         >
                                                                           <h4
                                                                             className=""
-                                                                          />
+                                                                          >
+                                                                            Label 1
+                                                                          </h4>
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
                                                                     </button>
@@ -1453,6 +1470,7 @@ exports[`Tabs renders 1`] = `
                                                               </li>
                                                             </Tab>
                                                             <Tab
+                                                              aria-label="Label 2"
                                                               className="react-tabs__tab"
                                                               disabledClassName="react-tabs__tab--disabled"
                                                               focus={false}
@@ -1470,6 +1488,7 @@ exports[`Tabs renders 1`] = `
                                                               <li
                                                                 aria-controls="react-tabs-3"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 2"
                                                                 aria-selected="false"
                                                                 className="react-tabs__tab"
                                                                 id="react-tabs-2"
@@ -1479,9 +1498,7 @@ exports[`Tabs renders 1`] = `
                                                                 role="tab"
                                                                 tabIndex="-1"
                                                               >
-                                                                <styles__TabLabelContainer
-                                                                  tabIndex={false}
-                                                                >
+                                                                <styles__TabLabelContainer>
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
@@ -1533,11 +1550,9 @@ exports[`Tabs renders 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
-                                                                    tabIndex={false}
                                                                   >
                                                                     <button
                                                                       className="c7"
-                                                                      tabIndex={false}
                                                                     >
                                                                       <styles__TabLabel
                                                                         wrapLabel={false}
@@ -1570,7 +1585,9 @@ exports[`Tabs renders 1`] = `
                                                                         >
                                                                           <h4
                                                                             className=""
-                                                                          />
+                                                                          >
+                                                                            Label 2
+                                                                          </h4>
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
                                                                     </button>
@@ -1579,6 +1596,7 @@ exports[`Tabs renders 1`] = `
                                                               </li>
                                                             </Tab>
                                                             <Tab
+                                                              aria-label="Label 3"
                                                               className="react-tabs__tab"
                                                               disabledClassName="react-tabs__tab--disabled"
                                                               focus={false}
@@ -1596,6 +1614,7 @@ exports[`Tabs renders 1`] = `
                                                               <li
                                                                 aria-controls="react-tabs-5"
                                                                 aria-disabled="false"
+                                                                aria-label="Label 3"
                                                                 aria-selected="false"
                                                                 className="react-tabs__tab"
                                                                 id="react-tabs-4"
@@ -1605,9 +1624,7 @@ exports[`Tabs renders 1`] = `
                                                                 role="tab"
                                                                 tabIndex="-1"
                                                               >
-                                                                <styles__TabLabelContainer
-                                                                  tabIndex={false}
-                                                                >
+                                                                <styles__TabLabelContainer>
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
@@ -1659,11 +1676,9 @@ exports[`Tabs renders 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
-                                                                    tabIndex={false}
                                                                   >
                                                                     <button
                                                                       className="c7"
-                                                                      tabIndex={false}
                                                                     >
                                                                       <styles__TabLabel
                                                                         wrapLabel={false}
@@ -1696,7 +1711,9 @@ exports[`Tabs renders 1`] = `
                                                                         >
                                                                           <h4
                                                                             className=""
-                                                                          />
+                                                                          >
+                                                                            Label 3
+                                                                          </h4>
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
                                                                     </button>
@@ -1924,7 +1941,7 @@ exports[`Tabs renders 1`] = `
                                                           className="c2"
                                                         >
                                                           <Col
-                                                            tabindex="0"
+                                                            tabIndex="0"
                                                             xs={12}
                                                           >
                                                             <Col__StyledCol
@@ -1947,7 +1964,7 @@ exports[`Tabs renders 1`] = `
                                                                   "inherit",
                                                                 ]
                                                               }
-                                                              tabindex="0"
+                                                              tabIndex="0"
                                                               xs={12}
                                                             >
                                                               <StyledComponent
@@ -1995,26 +2012,25 @@ exports[`Tabs renders 1`] = `
                                                                     "inherit",
                                                                   ]
                                                                 }
-                                                                tabindex="0"
+                                                                tabIndex="0"
                                                                 xs={12}
                                                               >
                                                                 <div
                                                                   className="c10"
+                                                                  tabIndex="0"
                                                                 >
                                                                   <Panel
                                                                     copy="en"
-                                                                    onOpen={null}
-                                                                    open={null}
                                                                   >
                                                                     <div
                                                                       copy="en"
-                                                                      onOpen={null}
-                                                                      open={null}
                                                                     >
                                                                       <Panel
+                                                                        heading="Label 1"
                                                                         id="1"
                                                                       >
                                                                         <div
+                                                                          heading="Label 1"
                                                                           id="1"
                                                                         >
                                                                           Content 1

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -13,7 +13,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c11 {
+.c12 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -58,7 +58,7 @@ exports[`Tabs renders 1`] = `
   width: 100%;
 }
 
-.c9 {
+.c10 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -73,7 +73,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c10 {
+.c11 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -134,9 +134,19 @@ exports[`Tabs renders 1`] = `
 
 .c4 {
   overflow-x: hidden;
+  position: relative;
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.c6 {
   position: relative;
   -webkit-transition: 0.9s all ease;
   transition: 0.9s all ease;
@@ -147,14 +157,14 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c7 {
+.c8 {
   height: 100%;
   display: block;
   padding: 8px 0px 4px 0;
   border-bottom: 4px solid transparent;
 }
 
-.c6 {
+.c7 {
   border: none;
   background-color: #fff;
   color: inherit;
@@ -165,21 +175,21 @@ exports[`Tabs renders 1`] = `
   border-radius: 5px;
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
-  border: none;
+  border-color: transparent;
 }
 
-.c6:active {
+.c7:active {
   outline: none;
   border: 2px solid transparent;
 }
 
-.c6::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: 0;
 }
 
-.c8 {
+.c9 {
   border: none;
   background-color: #fff;
   color: inherit;
@@ -190,17 +200,17 @@ exports[`Tabs renders 1`] = `
   border-radius: 5px;
 }
 
-.c8:focus {
+.c9:focus {
   outline: none;
-  border: 2px solid rgb(151,151,151);
+  border-color: rgb(151,151,151);
 }
 
-.c8:active {
+.c9:active {
   outline: none;
   border: 2px solid transparent;
 }
 
-.c8::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: 0;
 }
 
@@ -240,35 +250,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
@@ -364,11 +374,13 @@ exports[`Tabs renders 1`] = `
   onOpen={null}
   open={null}
   rightArrowLabel="Move menu to the right"
+  wrapLabels={false}
 >
   <styles__TabsContainer
     copy="en"
     onOpen={null}
     open={null}
+    wrapLabels={false}
   >
     <StyledComponent
       copy="en"
@@ -382,6 +394,7 @@ exports[`Tabs renders 1`] = `
             "lastClassName": "c0",
             "rules": Array [
               "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 1px;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
+              [Function],
             ],
           },
           "displayName": "styles__TabsContainer",
@@ -408,7 +421,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c11 {
+.c12 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -453,7 +466,7 @@ exports[`Tabs renders 1`] = `
   width: 100%;
 }
 
-.c9 {
+.c10 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -468,7 +481,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c10 {
+.c11 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -529,9 +542,19 @@ exports[`Tabs renders 1`] = `
 
 .c4 {
   overflow-x: hidden;
+  position: relative;
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.c6 {
   position: relative;
   -webkit-transition: 0.9s all ease;
   transition: 0.9s all ease;
@@ -542,14 +565,14 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c7 {
+.c8 {
   height: 100%;
   display: block;
   padding: 8px 0px 4px 0;
   border-bottom: 4px solid transparent;
 }
 
-.c6 {
+.c7 {
   border: none;
   background-color: #fff;
   color: inherit;
@@ -560,21 +583,21 @@ exports[`Tabs renders 1`] = `
   border-radius: 5px;
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
-  border: none;
+  border-color: transparent;
 }
 
-.c6:active {
+.c7:active {
   outline: none;
   border: 2px solid transparent;
 }
 
-.c6::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: 0;
 }
 
-.c8 {
+.c9 {
   border: none;
   background-color: #fff;
   color: inherit;
@@ -585,17 +608,17 @@ exports[`Tabs renders 1`] = `
   border-radius: 5px;
 }
 
-.c8:focus {
+.c9:focus {
   outline: none;
-  border: 2px solid rgb(151,151,151);
+  border-color: rgb(151,151,151);
 }
 
-.c8:active {
+.c9:active {
   outline: none;
   border: 2px solid transparent;
 }
 
-.c8::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: 0;
 }
 
@@ -635,35 +658,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c11 {
+  .c12 {
     display: block;
     text-align: inherit;
   }
@@ -775,70 +798,74 @@ exports[`Tabs renders 1`] = `
                       <div
                         class="c5"
                       >
-                        <ul
-                          class="react-tabs__tab-list"
-                          role="tablist"
+                        <div
+                          class="c6"
                         >
-                          <li
-                            aria-controls="react-tabs-1"
-                            aria-disabled="false"
-                            aria-selected="true"
-                            class="react-tabs__tab react-tabs__tab--selected"
-                            id="react-tabs-0"
-                            role="tab"
-                            tabindex="-1"
+                          <ul
+                            class="react-tabs__tab-list"
+                            role="tablist"
                           >
-                            <button
-                              class="c6"
+                            <li
+                              aria-controls="react-tabs-1"
+                              aria-disabled="false"
+                              aria-selected="true"
+                              class="react-tabs__tab react-tabs__tab--selected"
+                              id="react-tabs-0"
+                              role="tab"
                               tabindex="-1"
                             >
-                              <h4
+                              <button
                                 class="c7"
-                              />
-                            </button>
-                          </li>
-                          <li
-                            aria-controls="react-tabs-3"
-                            aria-disabled="false"
-                            aria-selected="false"
-                            class="react-tabs__tab"
-                            id="react-tabs-2"
-                            role="tab"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="c8"
+                                tabindex="-1"
+                              >
+                                <h4
+                                  class="c8"
+                                />
+                              </button>
+                            </li>
+                            <li
+                              aria-controls="react-tabs-3"
+                              aria-disabled="false"
+                              aria-selected="false"
+                              class="react-tabs__tab"
+                              id="react-tabs-2"
+                              role="tab"
+                              tabindex="-1"
                             >
-                              <h4
-                                class="c7"
-                              />
-                            </button>
-                          </li>
-                          <li
-                            aria-controls="react-tabs-5"
-                            aria-disabled="false"
-                            aria-selected="false"
-                            class="react-tabs__tab"
-                            id="react-tabs-4"
-                            role="tab"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="c8"
+                              <button
+                                class="c9"
+                              >
+                                <h4
+                                  class="c8"
+                                />
+                              </button>
+                            </li>
+                            <li
+                              aria-controls="react-tabs-5"
+                              aria-disabled="false"
+                              aria-selected="false"
+                              class="react-tabs__tab"
+                              id="react-tabs-4"
+                              role="tab"
+                              tabindex="-1"
                             >
-                              <h4
-                                class="c7"
-                              />
-                            </button>
-                          </li>
-                        </ul>
+                              <button
+                                class="c9"
+                              >
+                                <h4
+                                  class="c8"
+                                />
+                              </button>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
                     </div>
                     <hr
-                      class="c9"
+                      class="c10"
                     />
                     <hr
-                      class="c10"
+                      class="c11"
                     />
                     <div
                       aria-labelledby="react-tabs-0"
@@ -853,7 +880,7 @@ exports[`Tabs renders 1`] = `
                           class="c2"
                         >
                           <div
-                            class="c11"
+                            class="c12"
                           >
                             <div
                               copy="en"
@@ -889,6 +916,7 @@ exports[`Tabs renders 1`] = `
       }
       onOpen={null}
       open={null}
+      wrapLabels={false}
     >
       <div
         className="c0"
@@ -1037,7 +1065,7 @@ exports[`Tabs renders 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                     "isStatic": false,
-                                    "lastClassName": "c11",
+                                    "lastClassName": "c12",
                                     "rules": Array [
                                       [Function],
                                       [Function],
@@ -1112,7 +1140,7 @@ exports[`Tabs renders 1`] = `
                                                 "isStatic": false,
                                                 "lastClassName": "c4",
                                                 "rules": Array [
-                                                  "overflow-x:hidden;",
+                                                  "overflow-x:hidden;position:relative;",
                                                 ],
                                               },
                                               "displayName": "styles__TabBorder",
@@ -1130,9 +1158,8 @@ exports[`Tabs renders 1`] = `
                                           <div
                                             className="c4"
                                           >
-                                            <styles__TabListContainer
-                                              key=".0"
-                                              positionToMove={0}
+                                            <styles__TabListOuterContainer
+                                              key=".1"
                                             >
                                               <StyledComponent
                                                 forwardedComponent={
@@ -1140,418 +1167,453 @@ exports[`Tabs renders 1`] = `
                                                     "$$typeof": Symbol(react.forward_ref),
                                                     "attrs": Array [],
                                                     "componentStyle": ComponentStyle {
-                                                      "componentId": "styles__TabListContainer-fcx45d-2",
+                                                      "componentId": "styles__TabListOuterContainer-fcx45d-2",
                                                       "isStatic": false,
                                                       "lastClassName": "c5",
                                                       "rules": Array [
-                                                        "position:relative;transition:0.9s all ease;padding-right:24px;transform:translate(",
-                                                        [Function],
-                                                        "px);white-space:nowrap;",
+                                                        "display:flex;position:relative;overflow:hidden;",
                                                       ],
                                                     },
-                                                    "displayName": "styles__TabListContainer",
+                                                    "displayName": "styles__TabListOuterContainer",
                                                     "foldedComponentIds": Array [],
                                                     "render": [Function],
-                                                    "styledComponentId": "styles__TabListContainer-fcx45d-2",
+                                                    "styledComponentId": "styles__TabListOuterContainer-fcx45d-2",
                                                     "target": "div",
                                                     "toString": [Function],
                                                     "warnTooManyClasses": [Function],
                                                     "withComponent": [Function],
                                                   }
                                                 }
-                                                forwardedRef={
-                                                  Object {
-                                                    "current": <div
-                                                      class="c5"
-                                                    >
-                                                      <ul
-                                                        class="react-tabs__tab-list"
-                                                        role="tablist"
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-1"
-                                                          aria-disabled="false"
-                                                          aria-selected="true"
-                                                          class="react-tabs__tab react-tabs__tab--selected"
-                                                          id="react-tabs-0"
-                                                          role="tab"
-                                                          tabindex="-1"
-                                                        >
-                                                          <button
-                                                            class="c6"
-                                                            tabindex="-1"
-                                                          >
-                                                            <h4
-                                                              class="c7"
-                                                            />
-                                                          </button>
-                                                        </li>
-                                                        <li
-                                                          aria-controls="react-tabs-3"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          class="react-tabs__tab"
-                                                          id="react-tabs-2"
-                                                          role="tab"
-                                                          tabindex="-1"
-                                                        >
-                                                          <button
-                                                            class="c8"
-                                                          >
-                                                            <h4
-                                                              class="c7"
-                                                            />
-                                                          </button>
-                                                        </li>
-                                                        <li
-                                                          aria-controls="react-tabs-5"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          class="react-tabs__tab"
-                                                          id="react-tabs-4"
-                                                          role="tab"
-                                                          tabindex="-1"
-                                                        >
-                                                          <button
-                                                            class="c8"
-                                                          >
-                                                            <h4
-                                                              class="c7"
-                                                            />
-                                                          </button>
-                                                        </li>
-                                                      </ul>
-                                                    </div>,
-                                                  }
-                                                }
-                                                positionToMove={0}
+                                                forwardedRef={null}
                                               >
                                                 <div
                                                   className="c5"
                                                 >
-                                                  <TabList
-                                                    className="react-tabs__tab-list"
+                                                  <styles__TabListContainer
                                                     key=".0"
-                                                    style={
-                                                      Object {
-                                                        "width": undefined,
-                                                      }
-                                                    }
+                                                    positionToMove={0}
                                                   >
-                                                    <ul
-                                                      className="react-tabs__tab-list"
-                                                      role="tablist"
-                                                      style={
+                                                    <StyledComponent
+                                                      forwardedComponent={
                                                         Object {
-                                                          "width": undefined,
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "attrs": Array [],
+                                                          "componentStyle": ComponentStyle {
+                                                            "componentId": "styles__TabListContainer-fcx45d-3",
+                                                            "isStatic": false,
+                                                            "lastClassName": "c6",
+                                                            "rules": Array [
+                                                              "position:relative;transition:0.9s all ease;padding-right:24px;transform:translate(",
+                                                              [Function],
+                                                              "px);white-space:nowrap;",
+                                                            ],
+                                                          },
+                                                          "displayName": "styles__TabListContainer",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "styles__TabListContainer-fcx45d-3",
+                                                          "target": "div",
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
                                                         }
                                                       }
-                                                    >
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-0"
-                                                        key=".$0"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-1"
-                                                        selected={true}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabIndex="-1"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-1"
-                                                          aria-disabled="false"
-                                                          aria-selected="true"
-                                                          className="react-tabs__tab react-tabs__tab--selected"
-                                                          id="react-tabs-0"
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <styles__TabLabelContainer
-                                                            isActive={true}
-                                                            tabIndex="-1"
+                                                      forwardedRef={
+                                                        Object {
+                                                          "current": <div
+                                                            class="c6"
                                                           >
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c8",
-                                                                    "rules": Array [
-                                                                      "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border:",
-                                                                      [Function],
-                                                                      ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabelContainer",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                  "target": "button",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              isActive={true}
-                                                              tabIndex="-1"
+                                                            <ul
+                                                              class="react-tabs__tab-list"
+                                                              role="tablist"
                                                             >
-                                                              <button
-                                                                className="c6"
+                                                              <li
+                                                                aria-controls="react-tabs-1"
+                                                                aria-disabled="false"
+                                                                aria-selected="true"
+                                                                class="react-tabs__tab react-tabs__tab--selected"
+                                                                id="react-tabs-0"
+                                                                role="tab"
+                                                                tabindex="-1"
+                                                              >
+                                                                <button
+                                                                  class="c7"
+                                                                  tabindex="-1"
+                                                                >
+                                                                  <h4
+                                                                    class="c8"
+                                                                  />
+                                                                </button>
+                                                              </li>
+                                                              <li
+                                                                aria-controls="react-tabs-3"
+                                                                aria-disabled="false"
+                                                                aria-selected="false"
+                                                                class="react-tabs__tab"
+                                                                id="react-tabs-2"
+                                                                role="tab"
+                                                                tabindex="-1"
+                                                              >
+                                                                <button
+                                                                  class="c9"
+                                                                >
+                                                                  <h4
+                                                                    class="c8"
+                                                                  />
+                                                                </button>
+                                                              </li>
+                                                              <li
+                                                                aria-controls="react-tabs-5"
+                                                                aria-disabled="false"
+                                                                aria-selected="false"
+                                                                class="react-tabs__tab"
+                                                                id="react-tabs-4"
+                                                                role="tab"
+                                                                tabindex="-1"
+                                                              >
+                                                                <button
+                                                                  class="c9"
+                                                                >
+                                                                  <h4
+                                                                    class="c8"
+                                                                  />
+                                                                </button>
+                                                              </li>
+                                                            </ul>
+                                                          </div>,
+                                                        }
+                                                      }
+                                                      positionToMove={0}
+                                                    >
+                                                      <div
+                                                        className="c6"
+                                                      >
+                                                        <TabList
+                                                          className="react-tabs__tab-list"
+                                                          key=".0"
+                                                          style={
+                                                            Object {
+                                                              "width": undefined,
+                                                            }
+                                                          }
+                                                        >
+                                                          <ul
+                                                            className="react-tabs__tab-list"
+                                                            role="tablist"
+                                                            style={
+                                                              Object {
+                                                                "width": undefined,
+                                                              }
+                                                            }
+                                                          >
+                                                            <Tab
+                                                              className="react-tabs__tab"
+                                                              disabledClassName="react-tabs__tab--disabled"
+                                                              focus={false}
+                                                              id="react-tabs-0"
+                                                              key=".$0"
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              panelId="react-tabs-1"
+                                                              selected={true}
+                                                              selectedClassName="react-tabs__tab--selected"
+                                                              tabIndex="-1"
+                                                              tabRef={[Function]}
+                                                            >
+                                                              <li
+                                                                aria-controls="react-tabs-1"
+                                                                aria-disabled="false"
+                                                                aria-selected="true"
+                                                                className="react-tabs__tab react-tabs__tab--selected"
+                                                                id="react-tabs-0"
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                role="tab"
                                                                 tabIndex="-1"
                                                               >
-                                                                <styles__TabLabel>
+                                                                <styles__TabLabelContainer
+                                                                  isActive={true}
+                                                                  tabIndex="-1"
+                                                                >
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "styles__TabLabel-fcx45d-3",
+                                                                          "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c7",
+                                                                          "lastClassName": "c9",
                                                                           "rules": Array [
-                                                                            "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
+                                                                            [Function],
+                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
                                                                           ],
                                                                         },
-                                                                        "displayName": "styles__TabLabel",
+                                                                        "displayName": "styles__TabLabelContainer",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                        "target": "h4",
+                                                                        "styledComponentId": "styles__TabLabelContainer-fcx45d-7",
+                                                                        "target": "button",
                                                                         "toString": [Function],
                                                                         "warnTooManyClasses": [Function],
                                                                         "withComponent": [Function],
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
+                                                                    isActive={true}
+                                                                    tabIndex="-1"
                                                                   >
-                                                                    <h4
+                                                                    <button
                                                                       className="c7"
-                                                                    />
+                                                                      tabIndex="-1"
+                                                                    >
+                                                                      <styles__TabLabel>
+                                                                        <StyledComponent
+                                                                          forwardedComponent={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "attrs": Array [],
+                                                                              "componentStyle": ComponentStyle {
+                                                                                "componentId": "styles__TabLabel-fcx45d-4",
+                                                                                "isStatic": false,
+                                                                                "lastClassName": "c8",
+                                                                                "rules": Array [
+                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                ],
+                                                                              },
+                                                                              "displayName": "styles__TabLabel",
+                                                                              "foldedComponentIds": Array [],
+                                                                              "render": [Function],
+                                                                              "styledComponentId": "styles__TabLabel-fcx45d-4",
+                                                                              "target": "h4",
+                                                                              "toString": [Function],
+                                                                              "warnTooManyClasses": [Function],
+                                                                              "withComponent": [Function],
+                                                                            }
+                                                                          }
+                                                                          forwardedRef={null}
+                                                                        >
+                                                                          <h4
+                                                                            className="c8"
+                                                                          />
+                                                                        </StyledComponent>
+                                                                      </styles__TabLabel>
+                                                                    </button>
                                                                   </StyledComponent>
-                                                                </styles__TabLabel>
-                                                              </button>
-                                                            </StyledComponent>
-                                                          </styles__TabLabelContainer>
-                                                        </li>
-                                                      </Tab>
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-2"
-                                                        key=".$177556"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-3"
-                                                        selected={false}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabIndex="-1"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-3"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          className="react-tabs__tab"
-                                                          id="react-tabs-2"
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <styles__TabLabelContainer
-                                                            isActive={false}
-                                                            tabIndex={false}
-                                                          >
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c8",
-                                                                    "rules": Array [
-                                                                      "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border:",
-                                                                      [Function],
-                                                                      ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabelContainer",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                  "target": "button",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              isActive={false}
-                                                              tabIndex={false}
+                                                                </styles__TabLabelContainer>
+                                                              </li>
+                                                            </Tab>
+                                                            <Tab
+                                                              className="react-tabs__tab"
+                                                              disabledClassName="react-tabs__tab--disabled"
+                                                              focus={false}
+                                                              id="react-tabs-2"
+                                                              key=".$177556"
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              panelId="react-tabs-3"
+                                                              selected={false}
+                                                              selectedClassName="react-tabs__tab--selected"
+                                                              tabIndex="-1"
+                                                              tabRef={[Function]}
                                                             >
-                                                              <button
-                                                                className="c8"
-                                                                tabIndex={false}
+                                                              <li
+                                                                aria-controls="react-tabs-3"
+                                                                aria-disabled="false"
+                                                                aria-selected="false"
+                                                                className="react-tabs__tab"
+                                                                id="react-tabs-2"
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                role="tab"
+                                                                tabIndex="-1"
                                                               >
-                                                                <styles__TabLabel>
+                                                                <styles__TabLabelContainer
+                                                                  isActive={false}
+                                                                  tabIndex={false}
+                                                                >
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "styles__TabLabel-fcx45d-3",
+                                                                          "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c7",
+                                                                          "lastClassName": "c9",
                                                                           "rules": Array [
-                                                                            "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
+                                                                            [Function],
+                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
                                                                           ],
                                                                         },
-                                                                        "displayName": "styles__TabLabel",
+                                                                        "displayName": "styles__TabLabelContainer",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                        "target": "h4",
+                                                                        "styledComponentId": "styles__TabLabelContainer-fcx45d-7",
+                                                                        "target": "button",
                                                                         "toString": [Function],
                                                                         "warnTooManyClasses": [Function],
                                                                         "withComponent": [Function],
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
+                                                                    isActive={false}
+                                                                    tabIndex={false}
                                                                   >
-                                                                    <h4
-                                                                      className="c7"
-                                                                    />
+                                                                    <button
+                                                                      className="c9"
+                                                                      tabIndex={false}
+                                                                    >
+                                                                      <styles__TabLabel>
+                                                                        <StyledComponent
+                                                                          forwardedComponent={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "attrs": Array [],
+                                                                              "componentStyle": ComponentStyle {
+                                                                                "componentId": "styles__TabLabel-fcx45d-4",
+                                                                                "isStatic": false,
+                                                                                "lastClassName": "c8",
+                                                                                "rules": Array [
+                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                ],
+                                                                              },
+                                                                              "displayName": "styles__TabLabel",
+                                                                              "foldedComponentIds": Array [],
+                                                                              "render": [Function],
+                                                                              "styledComponentId": "styles__TabLabel-fcx45d-4",
+                                                                              "target": "h4",
+                                                                              "toString": [Function],
+                                                                              "warnTooManyClasses": [Function],
+                                                                              "withComponent": [Function],
+                                                                            }
+                                                                          }
+                                                                          forwardedRef={null}
+                                                                        >
+                                                                          <h4
+                                                                            className="c8"
+                                                                          />
+                                                                        </StyledComponent>
+                                                                      </styles__TabLabel>
+                                                                    </button>
                                                                   </StyledComponent>
-                                                                </styles__TabLabel>
-                                                              </button>
-                                                            </StyledComponent>
-                                                          </styles__TabLabelContainer>
-                                                        </li>
-                                                      </Tab>
-                                                      <Tab
-                                                        className="react-tabs__tab"
-                                                        disabledClassName="react-tabs__tab--disabled"
-                                                        focus={false}
-                                                        id="react-tabs-4"
-                                                        key=".$177559"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        panelId="react-tabs-5"
-                                                        selected={false}
-                                                        selectedClassName="react-tabs__tab--selected"
-                                                        tabIndex="-1"
-                                                        tabRef={[Function]}
-                                                      >
-                                                        <li
-                                                          aria-controls="react-tabs-5"
-                                                          aria-disabled="false"
-                                                          aria-selected="false"
-                                                          className="react-tabs__tab"
-                                                          id="react-tabs-4"
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="tab"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <styles__TabLabelContainer
-                                                            isActive={false}
-                                                            tabIndex={false}
-                                                          >
-                                                            <StyledComponent
-                                                              forwardedComponent={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "attrs": Array [],
-                                                                  "componentStyle": ComponentStyle {
-                                                                    "componentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                    "isStatic": false,
-                                                                    "lastClassName": "c8",
-                                                                    "rules": Array [
-                                                                      "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border:",
-                                                                      [Function],
-                                                                      ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
-                                                                    ],
-                                                                  },
-                                                                  "displayName": "styles__TabLabelContainer",
-                                                                  "foldedComponentIds": Array [],
-                                                                  "render": [Function],
-                                                                  "styledComponentId": "styles__TabLabelContainer-fcx45d-6",
-                                                                  "target": "button",
-                                                                  "toString": [Function],
-                                                                  "warnTooManyClasses": [Function],
-                                                                  "withComponent": [Function],
-                                                                }
-                                                              }
-                                                              forwardedRef={null}
-                                                              isActive={false}
-                                                              tabIndex={false}
+                                                                </styles__TabLabelContainer>
+                                                              </li>
+                                                            </Tab>
+                                                            <Tab
+                                                              className="react-tabs__tab"
+                                                              disabledClassName="react-tabs__tab--disabled"
+                                                              focus={false}
+                                                              id="react-tabs-4"
+                                                              key=".$177559"
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              panelId="react-tabs-5"
+                                                              selected={false}
+                                                              selectedClassName="react-tabs__tab--selected"
+                                                              tabIndex="-1"
+                                                              tabRef={[Function]}
                                                             >
-                                                              <button
-                                                                className="c8"
-                                                                tabIndex={false}
+                                                              <li
+                                                                aria-controls="react-tabs-5"
+                                                                aria-disabled="false"
+                                                                aria-selected="false"
+                                                                className="react-tabs__tab"
+                                                                id="react-tabs-4"
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                role="tab"
+                                                                tabIndex="-1"
                                                               >
-                                                                <styles__TabLabel>
+                                                                <styles__TabLabelContainer
+                                                                  isActive={false}
+                                                                  tabIndex={false}
+                                                                >
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "styles__TabLabel-fcx45d-3",
+                                                                          "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c7",
+                                                                          "lastClassName": "c9",
                                                                           "rules": Array [
-                                                                            "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
+                                                                            [Function],
+                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
                                                                           ],
                                                                         },
-                                                                        "displayName": "styles__TabLabel",
+                                                                        "displayName": "styles__TabLabelContainer",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "styles__TabLabel-fcx45d-3",
-                                                                        "target": "h4",
+                                                                        "styledComponentId": "styles__TabLabelContainer-fcx45d-7",
+                                                                        "target": "button",
                                                                         "toString": [Function],
                                                                         "warnTooManyClasses": [Function],
                                                                         "withComponent": [Function],
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
+                                                                    isActive={false}
+                                                                    tabIndex={false}
                                                                   >
-                                                                    <h4
-                                                                      className="c7"
-                                                                    />
+                                                                    <button
+                                                                      className="c9"
+                                                                      tabIndex={false}
+                                                                    >
+                                                                      <styles__TabLabel>
+                                                                        <StyledComponent
+                                                                          forwardedComponent={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "attrs": Array [],
+                                                                              "componentStyle": ComponentStyle {
+                                                                                "componentId": "styles__TabLabel-fcx45d-4",
+                                                                                "isStatic": false,
+                                                                                "lastClassName": "c8",
+                                                                                "rules": Array [
+                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                ],
+                                                                              },
+                                                                              "displayName": "styles__TabLabel",
+                                                                              "foldedComponentIds": Array [],
+                                                                              "render": [Function],
+                                                                              "styledComponentId": "styles__TabLabel-fcx45d-4",
+                                                                              "target": "h4",
+                                                                              "toString": [Function],
+                                                                              "warnTooManyClasses": [Function],
+                                                                              "withComponent": [Function],
+                                                                            }
+                                                                          }
+                                                                          forwardedRef={null}
+                                                                        >
+                                                                          <h4
+                                                                            className="c8"
+                                                                          />
+                                                                        </StyledComponent>
+                                                                      </styles__TabLabel>
+                                                                    </button>
                                                                   </StyledComponent>
-                                                                </styles__TabLabel>
-                                                              </button>
-                                                            </StyledComponent>
-                                                          </styles__TabLabelContainer>
-                                                        </li>
-                                                      </Tab>
-                                                    </ul>
-                                                  </TabList>
+                                                                </styles__TabLabelContainer>
+                                                              </li>
+                                                            </Tab>
+                                                          </ul>
+                                                        </TabList>
+                                                      </div>
+                                                    </StyledComponent>
+                                                  </styles__TabListContainer>
                                                 </div>
                                               </StyledComponent>
-                                            </styles__TabListContainer>
+                                            </styles__TabListOuterContainer>
                                           </div>
                                         </StyledComponent>
                                       </styles__TabBorder>
@@ -1572,7 +1634,7 @@ exports[`Tabs renders 1`] = `
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "HairlineDivider__StyledHairlineDivider-biamlk-0",
                                                   "isStatic": false,
-                                                  "lastClassName": "c9",
+                                                  "lastClassName": "c10",
                                                   "rules": Array [
                                                     "padding: 0;",
                                                     "margin: 0;",
@@ -1595,7 +1657,7 @@ exports[`Tabs renders 1`] = `
                                             vertical={false}
                                           >
                                             <hr
-                                              className="c9"
+                                              className="c10"
                                             />
                                           </StyledComponent>
                                         </HairlineDivider__StyledHairlineDivider>
@@ -1612,7 +1674,7 @@ exports[`Tabs renders 1`] = `
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
                                                   "isStatic": false,
-                                                  "lastClassName": "c10",
+                                                  "lastClassName": "c11",
                                                   "rules": Array [
                                                     "padding: 0;",
                                                     "margin: 0;",
@@ -1634,7 +1696,7 @@ exports[`Tabs renders 1`] = `
                                             forwardedRef={null}
                                           >
                                             <hr
-                                              className="c10"
+                                              className="c11"
                                             />
                                           </StyledComponent>
                                         </DimpleDivider__StyledDimpleDivider>
@@ -1798,7 +1860,7 @@ exports[`Tabs renders 1`] = `
                                                                     "componentStyle": ComponentStyle {
                                                                       "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                                                       "isStatic": false,
-                                                                      "lastClassName": "c11",
+                                                                      "lastClassName": "c12",
                                                                       "rules": Array [
                                                                         [Function],
                                                                         [Function],
@@ -1839,7 +1901,7 @@ exports[`Tabs renders 1`] = `
                                                                 xs={12}
                                                               >
                                                                 <div
-                                                                  className="c11"
+                                                                  className="c12"
                                                                 >
                                                                   <Panel
                                                                     copy="en"

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -1208,6 +1208,7 @@ exports[`Tabs renders 1`] = `
                                                   <styles__TabListContainer
                                                     key=".0"
                                                     positionToMove={0}
+                                                    wrapLabels={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -1221,7 +1222,9 @@ exports[`Tabs renders 1`] = `
                                                             "rules": Array [
                                                               "position:relative;transition:0.9s all ease;padding-right:24px;transform:translate(",
                                                               [Function],
-                                                              "px);white-space:nowrap;",
+                                                              "px);white-space:",
+                                                              [Function],
+                                                              ";",
                                                             ],
                                                           },
                                                           "displayName": "styles__TabListContainer",
@@ -1300,6 +1303,7 @@ exports[`Tabs renders 1`] = `
                                                         }
                                                       }
                                                       positionToMove={0}
+                                                      wrapLabels={false}
                                                     >
                                                       <div
                                                         className="c6"

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -13,7 +13,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c12 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -58,7 +58,7 @@ exports[`Tabs renders 1`] = `
   width: 100%;
 }
 
-.c10 {
+.c8 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -73,7 +73,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c11 {
+.c9 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -95,28 +95,21 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 .react-tabs__tab {
-  display: inline-block;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   cursor: pointer;
-  padding: 8px 10px 1px;
-  margin: 0 14px;
+  margin: 0 2px;
+  min-height: 45px;
   min-width: 44px;
   text-align: center;
   position: relative;
 }
 
-.c0 .react-tabs__tab:first-child {
-  margin-left: 2px;
-}
-
-.c0 .react-tabs__tab:hover h4 {
-  text-shadow: 0px 0px 1px #2a2c2e;
-  border-bottom: 4px solid #d8d8d8;
-}
-
 .c0 .react-tabs__tab:active h4,
 .c0 .react-tabs__tab.react-tabs__tab--selected h4 {
   text-shadow: 0px 0px 1px #2a2c2e;
-  border-bottom: 4px solid #71747a;
 }
 
 .c0 .react-tabs__tab:focus {
@@ -157,61 +150,70 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c8 {
-  height: 100%;
-  display: block;
-  padding: 8px 0px 4px 0;
-  border-bottom: 4px solid transparent;
-}
-
 .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border: none;
-  background-color: #fff;
+  background: none;
   color: inherit;
   -webkit-text-decoration: inherit;
   text-decoration: inherit;
-  padding: 1px 8px;
-  border: 2px solid transparent;
-  border-radius: 5px;
+  padding: 10px;
+  position: relative;
 }
 
 .c7:focus {
   outline: none;
-  border-color: transparent;
-}
-
-.c7:active {
-  outline: none;
-  border: 2px solid transparent;
 }
 
 .c7::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
-  border: none;
-  background-color: #fff;
-  color: inherit;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  padding: 1px 8px;
-  border: 2px solid transparent;
-  border-radius: 5px;
+.react-tabs__tab:not([aria-selected='true']) .c7:hover::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #d8d8d8;
 }
 
-.c9:focus {
-  outline: none;
-  border-color: rgb(151,151,151);
+.react-tabs__tab:not([aria-selected='true']) .c7:active::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
 }
 
-.c9:active {
-  outline: none;
-  border: 2px solid transparent;
+.react-tabs__tab:not([aria-selected='true']) .c7:focus:not(:active)::after {
+  content: '';
+  display: block;
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  border: solid 2px #979797;
+  border-radius: 6px;
 }
 
-.c9::-moz-focus-inner {
-  border: 0;
+.react-tabs__tab[aria-selected='true'] .c7::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
 }
 
 @media (max-width:575px) {
@@ -250,35 +252,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
@@ -365,6 +367,12 @@ exports[`Tabs renders 1`] = `
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+  }
+}
+
+@media (min-width:768px) {
+  .c0 .react-tabs__tab {
+    margin: 0 6px;
   }
 }
 
@@ -393,7 +401,7 @@ exports[`Tabs renders 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-block;cursor:pointer;padding:8px 10px 1px;margin:0 14px;min-width:44px;text-align:center;position:relative;&:first-child{margin-left:2px;}&:hover{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #d8d8d8;}}&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;border-bottom:4px solid #71747a;}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
+              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-flex;cursor:pointer;margin:0 2px;@media (min-width:768px){margin:0 6px;}min-height:45px;min-width:44px;text-align:center;position:relative;&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
               [Function],
             ],
           },
@@ -421,7 +429,7 @@ exports[`Tabs renders 1`] = `
   padding-right: 0;
 }
 
-.c12 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -466,7 +474,7 @@ exports[`Tabs renders 1`] = `
   width: 100%;
 }
 
-.c10 {
+.c8 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -481,7 +489,7 @@ exports[`Tabs renders 1`] = `
   background-color: #d8d8d8;
 }
 
-.c11 {
+.c9 {
   padding: 0;
   margin: 0;
   border-width: 0;
@@ -503,28 +511,21 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 .react-tabs__tab {
-  display: inline-block;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   cursor: pointer;
-  padding: 8px 10px 1px;
-  margin: 0 14px;
+  margin: 0 2px;
+  min-height: 45px;
   min-width: 44px;
   text-align: center;
   position: relative;
 }
 
-.c0 .react-tabs__tab:first-child {
-  margin-left: 2px;
-}
-
-.c0 .react-tabs__tab:hover h4 {
-  text-shadow: 0px 0px 1px #2a2c2e;
-  border-bottom: 4px solid #d8d8d8;
-}
-
 .c0 .react-tabs__tab:active h4,
 .c0 .react-tabs__tab.react-tabs__tab--selected h4 {
   text-shadow: 0px 0px 1px #2a2c2e;
-  border-bottom: 4px solid #71747a;
 }
 
 .c0 .react-tabs__tab:focus {
@@ -565,61 +566,70 @@ exports[`Tabs renders 1`] = `
   white-space: nowrap;
 }
 
-.c8 {
-  height: 100%;
-  display: block;
-  padding: 8px 0px 4px 0;
-  border-bottom: 4px solid transparent;
-}
-
 .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border: none;
-  background-color: #fff;
+  background: none;
   color: inherit;
   -webkit-text-decoration: inherit;
   text-decoration: inherit;
-  padding: 1px 8px;
-  border: 2px solid transparent;
-  border-radius: 5px;
+  padding: 10px;
+  position: relative;
 }
 
 .c7:focus {
   outline: none;
-  border-color: transparent;
-}
-
-.c7:active {
-  outline: none;
-  border: 2px solid transparent;
 }
 
 .c7::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
-  border: none;
-  background-color: #fff;
-  color: inherit;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  padding: 1px 8px;
-  border: 2px solid transparent;
-  border-radius: 5px;
+.react-tabs__tab:not([aria-selected='true']) .c7:hover::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #d8d8d8;
 }
 
-.c9:focus {
-  outline: none;
-  border-color: rgb(151,151,151);
+.react-tabs__tab:not([aria-selected='true']) .c7:active::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
 }
 
-.c9:active {
-  outline: none;
-  border: 2px solid transparent;
+.react-tabs__tab:not([aria-selected='true']) .c7:focus:not(:active)::after {
+  content: '';
+  display: block;
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  border: solid 2px #979797;
+  border-radius: 6px;
 }
 
-.c9::-moz-focus-inner {
-  border: 0;
+.react-tabs__tab[aria-selected='true'] .c7::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
 }
 
 @media (max-width:575px) {
@@ -658,35 +668,35 @@ exports[`Tabs renders 1`] = `
 }
 
 @media (max-width:575px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:576px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:768px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:992px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
 }
 
 @media (min-width:1200px) {
-  .c12 {
+  .c10 {
     display: block;
     text-align: inherit;
   }
@@ -773,6 +783,12 @@ exports[`Tabs renders 1`] = `
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+  }
+}
+
+@media (min-width:768px) {
+  .c0 .react-tabs__tab {
+    margin: 0 6px;
   }
 }
 
@@ -819,7 +835,7 @@ exports[`Tabs renders 1`] = `
                                 tabindex="-1"
                               >
                                 <h4
-                                  class="c8"
+                                  class=""
                                 />
                               </button>
                             </li>
@@ -833,10 +849,10 @@ exports[`Tabs renders 1`] = `
                               tabindex="-1"
                             >
                               <button
-                                class="c9"
+                                class="c7"
                               >
                                 <h4
-                                  class="c8"
+                                  class=""
                                 />
                               </button>
                             </li>
@@ -850,10 +866,10 @@ exports[`Tabs renders 1`] = `
                               tabindex="-1"
                             >
                               <button
-                                class="c9"
+                                class="c7"
                               >
                                 <h4
-                                  class="c8"
+                                  class=""
                                 />
                               </button>
                             </li>
@@ -862,10 +878,10 @@ exports[`Tabs renders 1`] = `
                       </div>
                     </div>
                     <hr
-                      class="c10"
+                      class="c8"
                     />
                     <hr
-                      class="c11"
+                      class="c9"
                     />
                     <div
                       aria-labelledby="react-tabs-0"
@@ -880,7 +896,7 @@ exports[`Tabs renders 1`] = `
                           class="c2"
                         >
                           <div
-                            class="c12"
+                            class="c10"
                           >
                             <div
                               copy="en"
@@ -1065,7 +1081,7 @@ exports[`Tabs renders 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                     "isStatic": false,
-                                    "lastClassName": "c12",
+                                    "lastClassName": "c10",
                                     "rules": Array [
                                       [Function],
                                       [Function],
@@ -1241,7 +1257,7 @@ exports[`Tabs renders 1`] = `
                                                                   tabindex="-1"
                                                                 >
                                                                   <h4
-                                                                    class="c8"
+                                                                    class=""
                                                                   />
                                                                 </button>
                                                               </li>
@@ -1255,10 +1271,10 @@ exports[`Tabs renders 1`] = `
                                                                 tabindex="-1"
                                                               >
                                                                 <button
-                                                                  class="c9"
+                                                                  class="c7"
                                                                 >
                                                                   <h4
-                                                                    class="c8"
+                                                                    class=""
                                                                   />
                                                                 </button>
                                                               </li>
@@ -1272,10 +1288,10 @@ exports[`Tabs renders 1`] = `
                                                                 tabindex="-1"
                                                               >
                                                                 <button
-                                                                  class="c9"
+                                                                  class="c7"
                                                                 >
                                                                   <h4
-                                                                    class="c8"
+                                                                    class=""
                                                                   />
                                                                 </button>
                                                               </li>
@@ -1334,7 +1350,6 @@ exports[`Tabs renders 1`] = `
                                                                 tabIndex="-1"
                                                               >
                                                                 <styles__TabLabelContainer
-                                                                  isActive={true}
                                                                   tabIndex="-1"
                                                                 >
                                                                   <StyledComponent
@@ -1345,11 +1360,36 @@ exports[`Tabs renders 1`] = `
                                                                         "componentStyle": ComponentStyle {
                                                                           "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c9",
+                                                                          "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
-                                                                            [Function],
-                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;&:focus{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #d8d8d8;
+",
+                                                                            "}&:active::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}&:focus:not(:active)::after{content:'';display:block;pointer-events:none;position:absolute;left:0;top:0;right:0;bottom:0;border:solid 2px #979797;border-radius:6px;}}.react-tabs__tab[aria-selected='true'] &{&::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}}",
                                                                           ],
                                                                         },
                                                                         "displayName": "styles__TabLabelContainer",
@@ -1363,14 +1403,15 @@ exports[`Tabs renders 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
-                                                                    isActive={true}
                                                                     tabIndex="-1"
                                                                   >
                                                                     <button
                                                                       className="c7"
                                                                       tabIndex="-1"
                                                                     >
-                                                                      <styles__TabLabel>
+                                                                      <styles__TabLabel
+                                                                        wrapLabel={false}
+                                                                      >
                                                                         <StyledComponent
                                                                           forwardedComponent={
                                                                             Object {
@@ -1379,9 +1420,9 @@ exports[`Tabs renders 1`] = `
                                                                               "componentStyle": ComponentStyle {
                                                                                 "componentId": "styles__TabLabel-fcx45d-4",
                                                                                 "isStatic": false,
-                                                                                "lastClassName": "c8",
+                                                                                "lastClassName": "gyhTug",
                                                                                 "rules": Array [
-                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                  [Function],
                                                                                 ],
                                                                               },
                                                                               "displayName": "styles__TabLabel",
@@ -1395,9 +1436,10 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          wrapLabel={false}
                                                                         >
                                                                           <h4
-                                                                            className="c8"
+                                                                            className=""
                                                                           />
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
@@ -1434,7 +1476,6 @@ exports[`Tabs renders 1`] = `
                                                                 tabIndex="-1"
                                                               >
                                                                 <styles__TabLabelContainer
-                                                                  isActive={false}
                                                                   tabIndex={false}
                                                                 >
                                                                   <StyledComponent
@@ -1445,11 +1486,36 @@ exports[`Tabs renders 1`] = `
                                                                         "componentStyle": ComponentStyle {
                                                                           "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c9",
+                                                                          "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
-                                                                            [Function],
-                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;&:focus{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #d8d8d8;
+",
+                                                                            "}&:active::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}&:focus:not(:active)::after{content:'';display:block;pointer-events:none;position:absolute;left:0;top:0;right:0;bottom:0;border:solid 2px #979797;border-radius:6px;}}.react-tabs__tab[aria-selected='true'] &{&::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}}",
                                                                           ],
                                                                         },
                                                                         "displayName": "styles__TabLabelContainer",
@@ -1463,14 +1529,15 @@ exports[`Tabs renders 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
-                                                                    isActive={false}
                                                                     tabIndex={false}
                                                                   >
                                                                     <button
-                                                                      className="c9"
+                                                                      className="c7"
                                                                       tabIndex={false}
                                                                     >
-                                                                      <styles__TabLabel>
+                                                                      <styles__TabLabel
+                                                                        wrapLabel={false}
+                                                                      >
                                                                         <StyledComponent
                                                                           forwardedComponent={
                                                                             Object {
@@ -1479,9 +1546,9 @@ exports[`Tabs renders 1`] = `
                                                                               "componentStyle": ComponentStyle {
                                                                                 "componentId": "styles__TabLabel-fcx45d-4",
                                                                                 "isStatic": false,
-                                                                                "lastClassName": "c8",
+                                                                                "lastClassName": "gyhTug",
                                                                                 "rules": Array [
-                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                  [Function],
                                                                                 ],
                                                                               },
                                                                               "displayName": "styles__TabLabel",
@@ -1495,9 +1562,10 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          wrapLabel={false}
                                                                         >
                                                                           <h4
-                                                                            className="c8"
+                                                                            className=""
                                                                           />
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
@@ -1534,7 +1602,6 @@ exports[`Tabs renders 1`] = `
                                                                 tabIndex="-1"
                                                               >
                                                                 <styles__TabLabelContainer
-                                                                  isActive={false}
                                                                   tabIndex={false}
                                                                 >
                                                                   <StyledComponent
@@ -1545,11 +1612,36 @@ exports[`Tabs renders 1`] = `
                                                                         "componentStyle": ComponentStyle {
                                                                           "componentId": "styles__TabLabelContainer-fcx45d-7",
                                                                           "isStatic": false,
-                                                                          "lastClassName": "c9",
+                                                                          "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "border:none;background-color:#fff;color:inherit;text-decoration:inherit;padding:1px 8px;border:2px solid transparent;border-radius:5px;&:focus{outline:none;border-color:",
-                                                                            [Function],
-                                                                            ";}&:active{outline:none;border:2px solid transparent;}::-moz-focus-inner{border:0;}",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;&:focus{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #d8d8d8;
+",
+                                                                            "}&:active::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}&:focus:not(:active)::after{content:'';display:block;pointer-events:none;position:absolute;left:0;top:0;right:0;bottom:0;border:solid 2px #979797;border-radius:6px;}}.react-tabs__tab[aria-selected='true'] &{&::after{",
+                                                                            "
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px #71757b;
+",
+                                                                            "}}",
                                                                           ],
                                                                         },
                                                                         "displayName": "styles__TabLabelContainer",
@@ -1563,14 +1655,15 @@ exports[`Tabs renders 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
-                                                                    isActive={false}
                                                                     tabIndex={false}
                                                                   >
                                                                     <button
-                                                                      className="c9"
+                                                                      className="c7"
                                                                       tabIndex={false}
                                                                     >
-                                                                      <styles__TabLabel>
+                                                                      <styles__TabLabel
+                                                                        wrapLabel={false}
+                                                                      >
                                                                         <StyledComponent
                                                                           forwardedComponent={
                                                                             Object {
@@ -1579,9 +1672,9 @@ exports[`Tabs renders 1`] = `
                                                                               "componentStyle": ComponentStyle {
                                                                                 "componentId": "styles__TabLabel-fcx45d-4",
                                                                                 "isStatic": false,
-                                                                                "lastClassName": "c8",
+                                                                                "lastClassName": "gyhTug",
                                                                                 "rules": Array [
-                                                                                  "height:100%;display:block;padding:8px 0px 4px 0;border-bottom:4px solid transparent;",
+                                                                                  [Function],
                                                                                 ],
                                                                               },
                                                                               "displayName": "styles__TabLabel",
@@ -1595,9 +1688,10 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          wrapLabel={false}
                                                                         >
                                                                           <h4
-                                                                            className="c8"
+                                                                            className=""
                                                                           />
                                                                         </StyledComponent>
                                                                       </styles__TabLabel>
@@ -1634,7 +1728,7 @@ exports[`Tabs renders 1`] = `
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "HairlineDivider__StyledHairlineDivider-biamlk-0",
                                                   "isStatic": false,
-                                                  "lastClassName": "c10",
+                                                  "lastClassName": "c8",
                                                   "rules": Array [
                                                     "padding: 0;",
                                                     "margin: 0;",
@@ -1657,7 +1751,7 @@ exports[`Tabs renders 1`] = `
                                             vertical={false}
                                           >
                                             <hr
-                                              className="c10"
+                                              className="c8"
                                             />
                                           </StyledComponent>
                                         </HairlineDivider__StyledHairlineDivider>
@@ -1674,7 +1768,7 @@ exports[`Tabs renders 1`] = `
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "DimpleDivider__StyledDimpleDivider-quxnvh-0",
                                                   "isStatic": false,
-                                                  "lastClassName": "c11",
+                                                  "lastClassName": "c9",
                                                   "rules": Array [
                                                     "padding: 0;",
                                                     "margin: 0;",
@@ -1696,7 +1790,7 @@ exports[`Tabs renders 1`] = `
                                             forwardedRef={null}
                                           >
                                             <hr
-                                              className="c11"
+                                              className="c9"
                                             />
                                           </StyledComponent>
                                         </DimpleDivider__StyledDimpleDivider>
@@ -1860,7 +1954,7 @@ exports[`Tabs renders 1`] = `
                                                                     "componentStyle": ComponentStyle {
                                                                       "componentId": "Col__StyledCol-sc-15yvjc7-0",
                                                                       "isStatic": false,
-                                                                      "lastClassName": "c12",
+                                                                      "lastClassName": "c10",
                                                                       "rules": Array [
                                                                         [Function],
                                                                         [Function],
@@ -1901,7 +1995,7 @@ exports[`Tabs renders 1`] = `
                                                                 xs={12}
                                                               >
                                                                 <div
-                                                                  className="c12"
+                                                                  className="c10"
                                                                 >
                                                                   <Panel
                                                                     copy="en"

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -399,7 +399,9 @@ exports[`Tabs renders 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-flex;cursor:pointer;margin:0 2px;@media (min-width:768px){margin:0 6px;}min-height:45px;min-width:44px;text-align:center;position:relative;&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px #2a2c2e;}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
+              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-flex;cursor:pointer;margin:0 2px;@media (min-width:768px){margin:0 6px;}min-height:45px;min-width:44px;text-align:center;position:relative;&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px ",
+              "#2a2c2e",
+              ";}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
               [Function],
             ],
           },

--- a/packages/Tabs/package.json
+++ b/packages/Tabs/package.json
@@ -26,6 +26,7 @@
     "styled-components": "^4.1.3"
   },
   "dependencies": {
+    "@tds/core-colours": "^2.2.1",
     "@tds/core-flex-grid": "^4.0.1",
     "@tds/core-interactive-icon": "^2.1.0",
     "@tds/util-helpers": "^1.5.0",

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -10,29 +10,21 @@ export const TabsContainer = styled.div`
     padding: 2px 0 0 0;
   }
   .react-tabs__tab {
-    display: inline-block;
+    display: inline-flex;
     cursor: pointer;
-    padding: 8px 10px 1px;
-    margin: 0 14px;
+    margin: 0 2px;
+    @media (min-width: 768px) {
+      margin: 0 6px;
+    }
+    min-height: 45px;
     min-width: 44px;
     text-align: center;
     position: relative;
-    &:first-child {
-      margin-left: 2px;
-    }
-
-    &:hover {
-      h4 {
-        text-shadow: 0px 0px 1px #2a2c2e;
-        border-bottom: 4px solid #d8d8d8;
-      }
-    }
 
     &:active,
     &.react-tabs__tab--selected {
       h4 {
         text-shadow: 0px 0px 1px #2a2c2e;
-        border-bottom: 4px solid #71747a;
       }
     }
     &:focus {
@@ -58,16 +50,9 @@ export const TabsContainer = styled.div`
       }
 
       .react-tabs__tab {
-        max-width: 180px;
         flex: 0 0 auto;
         display: flex;
         white-space: initial;
-
-        h4 {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
       }
     `}
 `
@@ -92,10 +77,14 @@ export const TabListContainer = styled.div`
 `
 
 export const TabLabel = styled.h4`
-  height: 100%;
-  display: block;
-  padding: 8px 0px 4px 0;
-  border-bottom: 4px solid transparent;
+  ${props =>
+    props.wrapLabel &&
+    css`
+      max-width: 144px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    `}
 `
 
 export const TabArrows = styled.div`
@@ -145,24 +134,61 @@ export const ArrowInner = styled.div`
       border-left: 1px solid #d8d8d8;
     `};
 `
+const pseudoBar = isSelected => `
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 0;
+  border-top: solid 4px ${isSelected ? '#71757b' : '#d8d8d8'};
+`
 
 export const TabLabelContainer = styled.button`
+  display: flex;
+  align-items: center;
   border: none;
-  background-color: #fff;
+  background: none;
   color: inherit;
   text-decoration: inherit;
-  padding: 1px 8px;
-  border: 2px solid transparent;
-  border-radius: 5px;
+  padding: 10px;
+  position: relative;
+
   &:focus {
     outline: none;
-    border-color: ${props => (props.isActive ? 'transparent' : 'rgb(151, 151, 151)')};
   }
-  &:active {
-    outline: none;
-    border: 2px solid transparent;
-  }
+
   ::-moz-focus-inner {
     border: 0;
+  }
+
+  // not in an active tab
+  .react-tabs__tab:not([aria-selected='true']) & {
+    &:hover::after {
+      ${pseudoBar(false)}
+    }
+
+    &:active::after {
+      ${pseudoBar(true)}
+    }
+
+    &:focus:not(:active)::after {
+      content: '';
+      display: block;
+      pointer-events: none;
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      border: solid 2px #979797;
+      border-radius: 6px;
+    }
+  }
+
+  // in an active tab
+  .react-tabs__tab[aria-selected='true'] & {
+    &::after {
+      ${pseudoBar(true)}
+    }
   }
 `

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -73,7 +73,7 @@ export const TabListContainer = styled.div`
   transition: 0.9s all ease;
   padding-right: 24px;
   transform: translate(${props => props.positionToMove}px);
-  white-space: nowrap;
+  white-space: ${props => (props.wrapLabels ? 'normal' : 'nowrap')};
 `
 
 export const TabLabel = styled.h4`

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -1,3 +1,4 @@
+import { colorWhite, colorGreyGainsboro, colorGreyShark, colorGreyRaven } from '@tds/core-colours'
 import styled, { css } from 'styled-components'
 
 export const TabsContainer = styled.div`
@@ -24,7 +25,7 @@ export const TabsContainer = styled.div`
     &:active,
     &.react-tabs__tab--selected {
       h4 {
-        text-shadow: 0px 0px 1px #2a2c2e;
+        text-shadow: 0px 0px 1px ${colorGreyShark};
       }
     }
     &:focus {
@@ -119,19 +120,19 @@ export const TabArrows = styled.div`
     `};
 `
 export const ArrowInner = styled.div`
-  background: #fff;
+  background: ${colorWhite};
   display: flex;
   align-items: center;
   ${props =>
     props.direction === 'left' &&
     css`
-      border-right: 1px solid #d8d8d8;
+      border-right: 1px solid ${colorGreyGainsboro};
     `};
 
   ${props =>
     props.direction === 'right' &&
     css`
-      border-left: 1px solid #d8d8d8;
+      border-left: 1px solid ${colorGreyGainsboro};
     `};
 `
 const pseudoBar = isSelected => `
@@ -140,7 +141,7 @@ const pseudoBar = isSelected => `
   left: 10px;
   right: 10px;
   bottom: 0;
-  border-top: solid 4px ${isSelected ? '#71757b' : '#d8d8d8'};
+  border-top: solid 4px ${isSelected ? colorGreyRaven : colorGreyGainsboro};
 `
 
 export const TabLabelContainer = styled.button`

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -48,10 +48,39 @@ export const TabsContainer = styled.div`
       margin-top: 0;
     }
   }
+
+  ${props =>
+    props.wrapLabels &&
+    css`
+      .react-tabs__tab-list {
+        display: flex;
+        position: relative;
+      }
+
+      .react-tabs__tab {
+        max-width: 180px;
+        flex: 0 0 auto;
+        display: flex;
+        white-space: initial;
+
+        h4 {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+      }
+    `}
 `
 
 export const TabBorder = styled.div`
   overflow-x: hidden;
+  position: relative;
+`
+
+export const TabListOuterContainer = styled.div`
+  display: flex;
+  position: relative;
+  overflow: hidden;
 `
 
 export const TabListContainer = styled.div`
@@ -71,9 +100,12 @@ export const TabLabel = styled.h4`
 
 export const TabArrows = styled.div`
   position: absolute;
-  top: 22px;
+  top: 0;
+  padding: 2px 0;
   z-index: 10;
-  padding: 5px 0;
+  height: calc(100% - 8px);
+  display: flex;
+  align-items: stretch;
   cursor: pointer;
   &:focus {
     outline: none;
@@ -99,6 +131,8 @@ export const TabArrows = styled.div`
 `
 export const ArrowInner = styled.div`
   background: #fff;
+  display: flex;
+  align-items: center;
   ${props =>
     props.direction === 'left' &&
     css`
@@ -122,7 +156,7 @@ export const TabLabelContainer = styled.button`
   border-radius: 5px;
   &:focus {
     outline: none;
-    border: ${props => (props.isActive ? 'none' : '2px solid rgb(151, 151, 151)')};
+    border-color: ${props => (props.isActive ? 'transparent' : 'rgb(151, 151, 151)')};
   }
   &:active {
     outline: none;


### PR DESCRIPTION
## Description

### Feature
Adds support for optionally wrapping tab labels to multiple lines, for use in marketing contexts, following the [provided designs](https://telus.invisionapp.com/d/main#/console/18077659/426618923/inspect). The Boolean `wrapLabels` prop will limit the max-width of labels to 144px, wrapping as necessary.

### Fixes
While building this feature, the following issues were identified and fixed:
- **IE11 support** (7e7b56e120adf0496c0fa6bdca05348b1c59c570): the scrolling tabs feature would crash in IE11 due to lack of [NodeList.prototype.forEach](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach) support
- **props/attrs warnings** (e530eecfb75a3fc6b9eb894a0b3ac27753fb0c9b): deconstruct `open`/`onOpen` props to remove from `rest`; fix issues with `tabIndex` attributes (case-sensitivity, undefined, null)
- **layout improvements** (f49f2c05b402b3fbb8c77215f8bda5ebdc449f3b): better align the label spacing, improve focus rings, and address shifting on select/focus, to more closely follow the designs:


![image](https://user-images.githubusercontent.com/93336/106032736-dafc5000-609e-11eb-96cf-ddaa71b65d07.png)


## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [X] New code is unit tested
- [X] make sure visual and accessibility tests pass
- [X] make sure code builds


Embargo exception approval: https://tdrm-285714.ue.r.appspot.com/?id=404062660