### PR TITLE
fix(community-tabs): fix focus state on active tab

### DIFF
--- a/packages/Tabs/Tabs.jsx
+++ b/packages/Tabs/Tabs.jsx
@@ -217,7 +217,9 @@ const Tabs = props => {
             ref={tabNavRef}
           >
             <TabLabelContainer>
-              <TabLabel wrapLabel={wrapLabels}>{tab.props.heading}</TabLabel>
+              <TabLabel tabIndex="-1" wrapLabel={wrapLabels}>
+                {tab.props.heading}
+              </TabLabel>
             </TabLabelContainer>
           </Tab>
         )

--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -170,9 +170,24 @@ exports[`Tabs renders 1`] = `
   border-radius: 6px;
 }
 
+.c7 > h4:focus {
+  outline: none;
+}
+
 .c7:focus {
   outline: none;
-  border: solid 2px #979797;
+}
+
+.c7:focus > h4:before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 2px solid #979797;
+  border-radius: 6px;
+  width: 100%;
+  height: 100%;
 }
 
 .c7:active {
@@ -580,9 +595,24 @@ exports[`Tabs renders 1`] = `
   border-radius: 6px;
 }
 
+.c7 > h4:focus {
+  outline: none;
+}
+
 .c7:focus {
   outline: none;
-  border: solid 2px #979797;
+}
+
+.c7:focus > h4:before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 2px solid #979797;
+  border-radius: 6px;
+  width: 100%;
+  height: 100%;
 }
 
 .c7:active {
@@ -824,6 +854,7 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
+                                  tabindex="-1"
                                 >
                                   Label 1
                                 </h4>
@@ -844,6 +875,7 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
+                                  tabindex="-1"
                                 >
                                   Label 2
                                 </h4>
@@ -864,6 +896,7 @@ exports[`Tabs renders 1`] = `
                               >
                                 <h4
                                   class=""
+                                  tabindex="-1"
                                 >
                                   Label 3
                                 </h4>
@@ -1254,6 +1287,7 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
+                                                                    tabindex="-1"
                                                                   >
                                                                     Label 1
                                                                   </h4>
@@ -1274,6 +1308,7 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
+                                                                    tabindex="-1"
                                                                   >
                                                                     Label 2
                                                                   </h4>
@@ -1294,6 +1329,7 @@ exports[`Tabs renders 1`] = `
                                                                 >
                                                                   <h4
                                                                     class=""
+                                                                    tabindex="-1"
                                                                   >
                                                                     Label 3
                                                                   </h4>
@@ -1367,7 +1403,7 @@ exports[`Tabs renders 1`] = `
                                                                           "isStatic": false,
                                                                           "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;&:focus{outline:none;border:solid 2px #979797;}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;> h4{&:focus{outline:none;}}&:focus{outline:none;> h4{&:before{content:'';display:block;position:absolute;top:0;left:0;border:2px solid #979797;border-radius:6px;width:100%;height:100%;}}}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
                                                                             "
   content: '';
   position: absolute;
@@ -1413,6 +1449,7 @@ exports[`Tabs renders 1`] = `
                                                                       className="c7"
                                                                     >
                                                                       <styles__TabLabel
+                                                                        tabIndex="-1"
                                                                         wrapLabel={false}
                                                                       >
                                                                         <StyledComponent
@@ -1439,10 +1476,12 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          tabIndex="-1"
                                                                           wrapLabel={false}
                                                                         >
                                                                           <h4
                                                                             className=""
+                                                                            tabIndex="-1"
                                                                           >
                                                                             Label 1
                                                                           </h4>
@@ -1493,7 +1532,7 @@ exports[`Tabs renders 1`] = `
                                                                           "isStatic": false,
                                                                           "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;&:focus{outline:none;border:solid 2px #979797;}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;> h4{&:focus{outline:none;}}&:focus{outline:none;> h4{&:before{content:'';display:block;position:absolute;top:0;left:0;border:2px solid #979797;border-radius:6px;width:100%;height:100%;}}}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
                                                                             "
   content: '';
   position: absolute;
@@ -1539,6 +1578,7 @@ exports[`Tabs renders 1`] = `
                                                                       className="c7"
                                                                     >
                                                                       <styles__TabLabel
+                                                                        tabIndex="-1"
                                                                         wrapLabel={false}
                                                                       >
                                                                         <StyledComponent
@@ -1565,10 +1605,12 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          tabIndex="-1"
                                                                           wrapLabel={false}
                                                                         >
                                                                           <h4
                                                                             className=""
+                                                                            tabIndex="-1"
                                                                           >
                                                                             Label 2
                                                                           </h4>
@@ -1619,7 +1661,7 @@ exports[`Tabs renders 1`] = `
                                                                           "isStatic": false,
                                                                           "lastClassName": "c7",
                                                                           "rules": Array [
-                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;&:focus{outline:none;border:solid 2px #979797;}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
+                                                                            "display:flex;align-items:center;border:none;background:none;color:inherit;text-decoration:inherit;padding:10px;position:relative;border:solid 2px transparent;border-radius:6px;> h4{&:focus{outline:none;}}&:focus{outline:none;> h4{&:before{content:'';display:block;position:absolute;top:0;left:0;border:2px solid #979797;border-radius:6px;width:100%;height:100%;}}}&:active{outline:none;}::-moz-focus-inner{border:0;}.react-tabs__tab:not([aria-selected='true']) &{&:hover::after{",
                                                                             "
   content: '';
   position: absolute;
@@ -1665,6 +1707,7 @@ exports[`Tabs renders 1`] = `
                                                                       className="c7"
                                                                     >
                                                                       <styles__TabLabel
+                                                                        tabIndex="-1"
                                                                         wrapLabel={false}
                                                                       >
                                                                         <StyledComponent
@@ -1691,10 +1734,12 @@ exports[`Tabs renders 1`] = `
                                                                             }
                                                                           }
                                                                           forwardedRef={null}
+                                                                          tabIndex="-1"
                                                                           wrapLabel={false}
                                                                         >
                                                                           <h4
                                                                             className=""
+                                                                            tabIndex="-1"
                                                                           >
                                                                             Label 3
                                                                           </h4>

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -156,9 +156,26 @@ export const TabLabelContainer = styled.button`
   border: solid 2px transparent;
   border-radius: 6px;
 
+  > h4 {
+    &:focus {
+      outline: none;
+    }
+  }
   &:focus {
     outline: none;
-    border: solid 2px #979797;
+    > h4 {
+      &:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        border: 2px solid #979797;
+        border-radius: 6px;
+        width: 100%;
+        height: 100%;
+      }
+    }
   }
   &:active {
     outline: none;


### PR DESCRIPTION
only apply focus state through keyboard interaction

<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->


## Description

* Remove focus state on active tab if the tab is clicked on
* It should only apply focus state with keyboard interaction

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
