### PR TITLE
fix(community-tabs): remove overlow-hidden

### DIFF
--- a/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
+++ b/packages/Tabs/__tests__/__snapshots__/Tabs.spec.jsx.snap
@@ -82,7 +82,6 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 {
-  overflow: hidden;
   padding-top: 6px;
 }
 
@@ -408,7 +407,7 @@ exports[`Tabs renders 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "overflow:hidden;padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-flex;cursor:pointer;margin:0 2px;@media (min-width:768px){margin:0 6px;}min-height:45px;min-width:44px;text-align:center;position:relative;&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px ",
+              "padding-top:6px;> div{position:relative;}.react-tabs__tab-list{padding:2px 0 0 0;}.react-tabs__tab{display:inline-flex;cursor:pointer;margin:0 2px;@media (min-width:768px){margin:0 6px;}min-height:45px;min-width:44px;text-align:center;position:relative;&:active,&.react-tabs__tab--selected{h4{text-shadow:0px 0px 1px ",
               "#2a2c2e",
               ";}}&:focus{outline:none;}}.react-tabs__tab-panel{display:none;&.react-tabs__tab-panel--selected{display:block;margin-top:0;}}",
               [Function],
@@ -507,7 +506,6 @@ exports[`Tabs renders 1`] = `
 }
 
 .c0 {
-  overflow: hidden;
   padding-top: 6px;
 }
 

--- a/packages/Tabs/styles.jsx
+++ b/packages/Tabs/styles.jsx
@@ -2,7 +2,6 @@ import { colorWhite, colorGreyGainsboro, colorGreyShark, colorGreyRaven } from '
 import styled, { css } from 'styled-components'
 
 export const TabsContainer = styled.div`
-  overflow: hidden;
   padding-top: 6px;
   > div {
     position: relative;


### PR DESCRIPTION
This will fix issue where content is being cut off in tabs

## Description
Changes will remove `overflow: hidden`  so that content is not cut off. See example of issue in Site Builder below.

<img width="575" alt="Screen Shot 2021-03-15 at 11 33 20 AM" src="https://user-images.githubusercontent.com/66031253/111203530-5e57ff00-8582-11eb-8705-54dae5986384.png">


## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
