### PR TITLE
feat(community-modal): update modal max-width

### DIFF
--- a/packages/Modal/Modal.jsx
+++ b/packages/Modal/Modal.jsx
@@ -34,6 +34,7 @@ const Modal = ({
   onClose,
   onConfirm,
   focusElementAfterClose,
+  width,
   ...rest
 }) => {
   const ModalOverlayRef = useRef(null)
@@ -110,7 +111,7 @@ const Modal = ({
             isOpen={isOpen}
             ref={ModalOverlayRef}
           >
-            <StyledModal ref={modalRef}>
+            <StyledModal ref={modalRef} width={width}>
               <ModalWrapper>
                 <Box inset={5}>
                   <StyledBox between={3}>
@@ -191,11 +192,18 @@ Modal.propTypes = {
    */
   focusElementAfterClose: PropTypes.oneOfType([PropTypes.shape({ current: PropTypes.any })])
     .isRequired,
+
+  /**
+   * Set the width of Modal
+   * Accepts a numeric value that lies in the range between minWidth(570px) - maxWidth(736px).
+   */
+  width: PropTypes.number,
 }
 
 Modal.defaultProps = {
   confirmCTAText: '',
   cancelCTAText: '',
+  width: 570,
   onConfirm: null,
 }
 

--- a/packages/Modal/Modal.jsx
+++ b/packages/Modal/Modal.jsx
@@ -194,8 +194,8 @@ Modal.propTypes = {
     .isRequired,
 
   /**
-   * Set the width of Modal
-   * Accepts a numeric value that lies in the range between minWidth(570px) - maxWidth(736px).
+   * Set the width of `Modal`.
+   * Accepts a numeric value that lies in the range between minWidth(570) - maxWidth(736).
    */
   width: PropTypes.number,
 }

--- a/packages/Modal/__tests__/Modal.spec.jsx
+++ b/packages/Modal/__tests__/Modal.spec.jsx
@@ -40,6 +40,16 @@ describe('Modal', () => {
     expect(modal).toHaveProp('data-some-attr', 'some value')
   })
 
+  it('should set default width(570px) when "width" props not provided', () => {
+    const modal = doMount()
+    expect(modal).toHaveProp('width', 570)
+  })
+
+  it('should set width based on "width" size provided', () => {
+    const modal = doMount({ width: 630 })
+    expect(modal).toHaveProp('width', 630)
+  })
+
   it('does not allow custom CSS', () => {
     const modal = doMount({
       className: 'my-custom-class',

--- a/packages/Modal/__tests__/__snapshots__/Modal.spec.jsx.snap
+++ b/packages/Modal/__tests__/__snapshots__/Modal.spec.jsx.snap
@@ -364,7 +364,9 @@ exports[`Modal renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     margin: 0 auto;
-    max-width: 570px;
+    max-width: 736px;
+    width: 570px;
+    min-width: 570px;
     height: auto;
     border-radius: 0.25rem;
     box-shadow: 0 0 16px 0 rgba(0,0,0,0.2);
@@ -405,6 +407,7 @@ exports[`Modal renders 1`] = `
   isOpen={true}
   onClose={[Function]}
   onConfirm={[Function]}
+  width={570}
 >
   <WithFocusTrap
     a11yText="modal dialog"
@@ -814,7 +817,9 @@ exports[`Modal renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     margin: 0 auto;
-    max-width: 570px;
+    max-width: 736px;
+    width: 570px;
+    min-width: 570px;
     height: auto;
     border-radius: 0.25rem;
     box-shadow: 0 0 16px 0 rgba(0,0,0,0.2);
@@ -852,6 +857,7 @@ exports[`Modal renders 1`] = `
                   >
                     <div
                       class="c1"
+                      width="570"
                     >
                       <div
                         class="c2"
@@ -944,7 +950,9 @@ exports[`Modal renders 1`] = `
                 className="c0"
                 data-testid="tds-modal-overlay"
               >
-                <styles__StyledModal>
+                <styles__StyledModal
+                  width={570}
+                >
                   <StyledComponent
                     forwardedComponent={
                       Object {
@@ -955,28 +963,7 @@ exports[`Modal renders 1`] = `
                           "isStatic": false,
                           "lastClassName": "c1",
                           "rules": Array [
-                            "height: 100%;",
-                            "width: 100%;",
-                            "position: relative;",
-                            "top: 0%;",
-                            "left: 0%;",
-                            "> button:first-child {",
-                            "display: flex;",
-                            "align-self: flex-end;",
-                            "background: none;",
-                            "border: none;",
-                            "margin: 1rem 0.5rem;",
-                            "}",
-                            "@media (min-width: 768px) {",
-                            "margin: 0 auto;",
-                            "max-width: 570px;",
-                            "height: auto;",
-                            "border-radius: 0.25rem;",
-                            "box-shadow: 0 0 16px 0 rgba(0,0,0,0.2);",
-                            "z-index: 2000;",
-                            "background-color: #fff;",
-                            "top: 29%;",
-                            "}",
+                            [Function],
                           ],
                         },
                         "displayName": "styles__StyledModal",
@@ -993,6 +980,7 @@ exports[`Modal renders 1`] = `
                       Object {
                         "current": <div
                           class="c1"
+                          width="570"
                         >
                           <div
                             class="c2"
@@ -1078,9 +1066,11 @@ exports[`Modal renders 1`] = `
                         </div>,
                       }
                     }
+                    width={570}
                   >
                     <div
                       className="c1"
+                      width={570}
                     >
                       <styles__ModalWrapper>
                         <StyledComponent

--- a/packages/Modal/styles.jsx
+++ b/packages/Modal/styles.jsx
@@ -23,29 +23,34 @@ export const FullScreenOverlay = styled.div(props => {
   return null
 })
 
-export const StyledModal = styled.div({
-  height: '100%',
-  width: '100%',
-  position: 'relative',
-  top: '0%',
-  left: '0%',
-  '> button:first-child': {
-    display: 'flex',
-    alignSelf: 'flex-end',
-    background: 'none',
-    border: 'none',
-    margin: '1rem 0.5rem',
-  },
-  ...media.from('md').css({
-    margin: '0 auto',
-    maxWidth: '570px',
-    height: 'auto',
-    borderRadius: '0.25rem',
-    boxShadow: '0 0 16px 0 rgba(0,0,0,0.2)',
-    zIndex: '2000',
-    backgroundColor: colorWhite,
-    top: '29%',
-  }),
+export const StyledModal = styled.div(props => {
+  const { width } = props
+  return {
+    height: '100%',
+    width: '100%',
+    position: 'relative',
+    top: '0%',
+    left: '0%',
+    '> button:first-child': {
+      display: 'flex',
+      alignSelf: 'flex-end',
+      background: 'none',
+      border: 'none',
+      margin: '1rem 0.5rem',
+    },
+    ...media.from('md').css({
+      margin: '0 auto',
+      maxWidth: '736px',
+      width: `${width}px`,
+      minWidth: '570px',
+      height: 'auto',
+      borderRadius: '0.25rem',
+      boxShadow: '0 0 16px 0 rgba(0,0,0,0.2)',
+      zIndex: '2000',
+      backgroundColor: colorWhite,
+      top: '29%',
+    }),
+  }
 })
 
 export const CTAWrapper = styled.div(props => {


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Description

Jira ticket [DJR-3335](https://telusdigital.atlassian.net/browse/DJR-3335)

**Current Issue:** 
Currently modal has a max-width limitation of 570px, so any flex-grid element inside modal having more than the default maxWidth causes the design broken

**Requirement** Modal width can expand up to 736px
 
 **Fix**: 
 Set the max-width of 736px
 Set the min-width of 570px
 Set the default width of 570px or by using `width` props provided to the Modal, that lies in the range of maxWidth-minWidth (i.e.: 570-736)


## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
