### PR TITLE
fix(community-input-group): change input group min width

### DIFF
--- a/packages/InputGroup/style.js
+++ b/packages/InputGroup/style.js
@@ -14,7 +14,7 @@ export const InputGroupStyle = styled.div(({ hasValue }) => ({
   height: '52px',
   width: '100%',
   maxWidth: '768px',
-  minWidth: '384px',
+  minWidth: '200px',
   borderRadius: '5px',
   '&:hover': {
     boxShadow: '0 0 0 1px #4B286D',


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

This is to fix the issue where the search button is cut off on mobile devices.

<img width="443" alt="Screen Shot 2021-03-17 at 10 59 47 AM" src="https://user-images.githubusercontent.com/36368604/111503245-f689eb80-871c-11eb-889b-1f991375741a.png">

## Description
Changes will set the `min-width` of `InputGroup` to `200px` to ensure search button is not hidden on mobile devices.

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
