### PR TITLE
feat(community-skeleton-provider): remove uuid to improve bundle size

### DIFF
--- a/packages/SkeletonProvider/package.json
+++ b/packages/SkeletonProvider/package.json
@@ -33,7 +33,6 @@
     "@tds/shared-styles": "^1.5.2",
     "@tds/util-helpers": "^1.5.0",
     "prop-types": "^15.6.2",
-    "recompose": "^0.30.0",
-    "uuid": "^3.3.2"
+    "recompose": "^0.30.0"
   }
 }

--- a/packages/SkeletonProvider/tds/Text.jsx
+++ b/packages/SkeletonProvider/tds/Text.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Text from '@tds/core-text'
-import uuid from 'uuid/v1'
 import styled from 'styled-components'
 import Skeleton from '../../Skeleton/Skeleton'
 import withSkeleton from '../withSkeleton'
@@ -44,8 +43,9 @@ const TextSkeleton = ({ skeleton, ...rest }) => {
 
   return (
     <StyledTextSkeleton>
-      {[...Array(lines)].map(() => (
-        <div key={uuid()}>
+      {[...Array(lines)].map((_, idx) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={idx}>
           <Skeleton size={skSize} characters={characters} />
         </div>
       ))}


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Description

This PR removes uuid and instead uses array indices as the `key` prop when mapping elements.  The main issue with using uuid is that it's bringing crypto into our browser bundles and this is very large (> 1MB in bundle builder). In the absence of a unique identifier, it's fine to use array indices as keys.

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
