### PR TITLE
fix(community-skeleton-provider): replaced recompose with react hooks

### DIFF
--- a/packages/SkeletonProvider/SkeletonProvider.jsx
+++ b/packages/SkeletonProvider/SkeletonProvider.jsx
@@ -1,17 +1,22 @@
-import React, { Fragment } from 'react'
+import React, { createContext } from 'react'
 import PropTypes from 'prop-types'
-import { withContext } from 'recompose'
 import AutoSkeletonizer from './AutoSkeletonizer'
 
-const SkeletonProvider = withContext({ show: PropTypes.bool }, props => ({
-  show: props.show,
-}))(props => <Fragment>{AutoSkeletonizer(props.children)}</Fragment>)
-
+export const SkeletonContext = createContext({ show: true })
+function SkeletonProvider({ show, children, ...rest }) {
+  return (
+    <SkeletonContext.Provider value={{ show }} {...rest}>
+      {AutoSkeletonizer(children)}
+    </SkeletonContext.Provider>
+  )
+}
 SkeletonProvider.propTypes = {
   show: PropTypes.bool,
+  children: PropTypes.node,
 }
 SkeletonProvider.defaultProps = {
   show: true,
+  children: null,
 }
 
 export default SkeletonProvider

--- a/packages/SkeletonProvider/package.json
+++ b/packages/SkeletonProvider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tds/community-skeleton-provider",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "",
   "main": "index.cjs.js",
   "module": "index.es.js",
@@ -32,7 +32,6 @@
     "@tds/core-colours": "^2.2.1",
     "@tds/shared-styles": "^1.5.2",
     "@tds/util-helpers": "^1.5.0",
-    "prop-types": "^15.6.2",
-    "recompose": "^0.30.0"
+    "prop-types": "^15.6.2"
   }
 }

--- a/packages/SkeletonProvider/withSkeleton.jsx
+++ b/packages/SkeletonProvider/withSkeleton.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
-import { getContext } from 'recompose'
 
-export const SkeletonRenderer = getContext({ show: PropTypes.bool })(props =>
-  props.show ? props.skeleton() : props.render()
-)
+import { SkeletonContext } from './SkeletonProvider'
+
+function SkeletonRenderer(props) {
+  const skeleton = useContext(SkeletonContext)
+  return skeleton.show ? props.skeleton() : props.render()
+}
 
 const getName = comp => comp.displayName || comp.name || 'Component'
 


### PR DESCRIPTION
fix(community-skeleton-provider): allow id and additional props

<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Related issues

See
 https://telusdigital.atlassian.net/browse/NEO-1230

## Description

The recompose package is no longer maintained and has currently a critical-level vulnerability.  In this PR, we replace the use of recompose with React hooks. 

## Checklist before submitting pull request

- Commits follow our [Developer Guide](https://github.com/telus/tds-community/blob/chore/template-hints/.github/CONTRIBUTING.md)
- [x] New code is unit tested
- [x] make sure visual and accessibility tests pass
- [x] make sure code builds
